### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,37 +6,38 @@ GLFW 3.0 Bindings for Go
 * You can help by submitting examples to http://github.com/tapir/glfw3-go-examples
 
 The library can be used as below:
+
 ```go
-	package main
-	
-	import (
-		"fmt"
-		glfw "github.com/tapir/glfw3-go"
-	)
-	
-	func errorCallback(err glfw.ErrorCode, desc string) {
-		fmt.Printf("%v: %v\n", err, desc)
+package main
+
+import (
+	"fmt"
+	glfw "github.com/tapir/glfw3-go"
+)
+
+func errorCallback(err glfw.ErrorCode, desc string) {
+	fmt.Printf("%v: %v\n", err, desc)
+}
+
+func main() {
+	glfw.SetErrorCallback(errorCallback)
+
+	if !glfw.Init() {
+		panic("Can't init glfw!")
 	}
-	
-	func main() {
-		glfw.SetErrorCallback(errorCallback)
-	
-		if !glfw.Init() {
-			panic("Can't init glfw!")
-		}
-		defer glfw.Terminate()
-	
-		window, err := glfw.CreateWindow(640, 480, "Testing", nil, nil)
-		if err != nil {
-			panic(err)
-		}
-		defer window.Destroy()
-	
-		window.MakeContextCurrent()
-	
-		for !window.ShouldClose() {
-			//Do OpenGL stuff
-			glfw.PollEvents()
-		}
+	defer glfw.Terminate()
+
+	window, err := glfw.CreateWindow(640, 480, "Testing", nil, nil)
+	if err != nil {
+		panic(err)
 	}
+
+	window.MakeContextCurrent()
+
+	for !window.ShouldClose() {
+		//Do OpenGL stuff
+		window.SwapBuffers()
+		glfw.PollEvents()
+	}
+}
 ```


### PR DESCRIPTION
gofmt'ed the example code (removes leading tabs).
Made it more similar to the example glfw3 at http://www.glfw.org/documentation.html.

The removed leading tabs make the content changes harder to see, so they are:
- Removed `defer window.Destroy()`
- Added `window.SwapBuffers()`

See if you like these changes and feel free to merge if so.
