### PR TITLE
Linker flags for Windows

### DIFF
--- a/glfw.go
+++ b/glfw.go
@@ -1,6 +1,10 @@
 package glfw3
 
-//#cgo LDFLAGS: -lglfw
+// Not sure about the darwin flag
+
+//#cgo windows LDFLAGS: -lglfw3 -lopengl32 -lgdi32
+//#cgo linux LDGLAGS: -lglfw
+//#cgo darwin LDFLAGS: -lglfw
 //#include <GLFW/glfw3.h>
 import "C"
 

--- a/glfw.go
+++ b/glfw.go
@@ -2,9 +2,15 @@ package glfw3
 
 // Not sure about the darwin flag
 
-//#cgo windows LDFLAGS: -lglfw3 -lopengl32 -lgdi32
+// Windows users: If you download the GLFW 64-bit binaries, when you copy over the contents of the lib folder make sure to rename
+// glfw3dll.a to libglfw3dll.a, it doesn't work otherwise.
+
+//#cgo windows LDFLAGS: -lglfw3dll -lopengl32 -lgdi32
 //#cgo linux LDGLAGS: -lglfw
 //#cgo darwin LDFLAGS: -lglfw
+//#ifdef _WIN32
+//  #define GLFW_DLL
+//#endif
 //#include <GLFW/glfw3.h>
 import "C"
 


### PR DESCRIPTION
The library didn't used to link on Windows (mingw-w64), I added some platform specific linker flags so it does.
