### PR TITLE
API finalization and bug fixes

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -4,7 +4,10 @@ package glfw3
 //#include <GLFW/glfw3.h>
 import "C"
 
-import "unsafe"
+import (
+	"errors"
+	"unsafe"
+)
 
 //SetClipboardString sets the system clipboard to the specified UTF-8 encoded
 //string.
@@ -17,6 +20,11 @@ func (w *Window) SetClipboardString(str string) {
 
 //GetClipboardString returns the contents of the system clipboard, if it
 //contains or is convertible to a UTF-8 encoded string.
-func (w *Window) GetClipboardString() string {
-	return C.GoString(C.glfwGetClipboardString(w.data))
+func (w *Window) GetClipboardString() (string, error) {
+	cs := C.glfwGetClipboardString(w.data)
+	if cs == nil {
+		return "", errors.New("Can't get clipboard string.")
+	}
+
+	return C.GoString(cs), nil
 }

--- a/context.go
+++ b/context.go
@@ -16,7 +16,7 @@ func (w *Window) MakeContextCurrent() {
 
 //DetachCurrentContext detaches the current context.
 func DetachCurrentContext() {
-    C.glfwMakeContextCurrent(nil)
+	C.glfwMakeContextCurrent(nil)
 }
 
 //GetCurrentContext returns the window whose context is current.

--- a/error.go
+++ b/error.go
@@ -32,6 +32,10 @@ func goErrorCB(code C.int, desc *C.char) {
 //
 //This function may be called before Init.
 func SetErrorCallback(cbfun func(code ErrorCode, desc string)) {
-	fErrorHolder = cbfun
-	C.glfwSetErrorCallbackCB()
+	if cbfun == nil {
+		C.glfwSetErrorCallback(nil)
+	} else {
+		fErrorHolder = cbfun
+		C.glfwSetErrorCallbackCB()
+	}
 }

--- a/input.go
+++ b/input.go
@@ -342,8 +342,12 @@ func (w *Window) SetCursorPosition(xpos, ypos float64) {
 //i.e. Focused will be false and the focus callback will have already been
 //called.
 func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, action Action, mods ModifierKey)) {
-	fKeyHolder = cbfun
-	C.glfwSetKeyCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetKeyCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fKeyHolder = cbfun
+		C.glfwSetKeyCallbackCB(w.data)
+	}
 }
 
 //SetCharacterCallback sets the character callback which is called when a
@@ -352,8 +356,12 @@ func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, act
 //The character callback is intended for text input. If you want to know whether
 //a specific key was pressed or released, use the key callback instead.
 func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
-	fCharHolder = cbfun
-	C.glfwSetCharCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetCharCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fCharHolder = cbfun
+		C.glfwSetCharCallbackCB(w.data)
+	}
 }
 
 //SetMouseButtonCallback sets the mouse button callback which is called when a
@@ -365,30 +373,46 @@ func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
 //the window has lost focus, i.e. Focused will be false and the focus
 //callback will have already been called.
 func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton, action Action, mod ModifierKey)) {
-	fMouseButtonHolder = cbfun
-	C.glfwSetMouseButtonCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetMouseButtonCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fMouseButtonHolder = cbfun
+		C.glfwSetMouseButtonCallbackCB(w.data)
+	}
 }
 
 //SetCursorPositionCallback sets the cursor position callback which is called
 //when the cursor is moved. The callback is provided with the position relative
 //to the upper-left corner of the client area of the window.
 func (w *Window) SetCursorPositionCallback(cbfun func(w *Window, xpos float64, ypos float64)) {
-	fCursorPosHolder = cbfun
-	C.glfwSetCursorPosCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetCursorPosCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fCursorPosHolder = cbfun
+		C.glfwSetCursorPosCallbackCB(w.data)
+	}
 }
 
 //SetCursorEnterCallback the cursor boundary crossing callback which is called
 //when the cursor enters or leaves the client area of the window.
 func (w *Window) SetCursorEnterCallback(cbfun func(w *Window, entered bool)) {
-	fCursorEnterHolder = cbfun
-	C.glfwSetCursorEnterCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetCursorEnterCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fCursorEnterHolder = cbfun
+		C.glfwSetCursorEnterCallbackCB(w.data)
+	}
 }
 
 //SetScrollCallback sets the scroll callback which is called when a scrolling
 //device is used, such as a mouse wheel or scrolling area of a touchpad.
 func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff float64)) {
-	fScrollHolder = cbfun
-	C.glfwSetScrollCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetScrollCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fScrollHolder = cbfun
+		C.glfwSetScrollCallbackCB(w.data)
+	}
 }
 
 //GetJoystickPresent returns whether the specified joystick is present.

--- a/input.go
+++ b/input.go
@@ -171,15 +171,15 @@ const (
 	KeyLast         Key = C.GLFW_KEY_LAST
 )
 
-//Mod corresponds to a modifier key.
-type Mod int
+//ModifierKey corresponds to a modifier key.
+type ModifierKey int
 
 //Modifier keys
 const (
-	ModShift   Mod = C.GLFW_MOD_SHIFT
-	ModControl Mod = C.GLFW_MOD_CONTROL
-	ModAlt     Mod = C.GLFW_MOD_ALT
-	ModSuper   Mod = C.GLFW_MOD_SUPER
+	ModShift   ModifierKey = C.GLFW_MOD_SHIFT
+	ModControl ModifierKey = C.GLFW_MOD_CONTROL
+	ModAlt     ModifierKey = C.GLFW_MOD_ALT
+	ModSuper   ModifierKey = C.GLFW_MOD_SUPER
 )
 
 //MouseButton corresponds to a mouse button.
@@ -231,17 +231,17 @@ const (
 )
 
 var (
-	fMouseButtonHolder func(w *Window, button MouseButton, action Action, mod Mod)
+	fMouseButtonHolder func(w *Window, button MouseButton, action Action, mod ModifierKey)
 	fCursorPosHolder   func(w *Window, xpos float64, ypos float64)
 	fCursorEnterHolder func(w *Window, entered bool)
 	fScrollHolder      func(w *Window, xoff float64, yoff float64)
-	fKeyHolder         func(w *Window, key Key, scancode int, action Action, mods Mod)
+	fKeyHolder         func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
 	fCharHolder        func(w *Window, char uint)
 )
 
 //export goMouseButtonCB
 func goMouseButtonCB(window unsafe.Pointer, button, action, mods C.int) {
-	fMouseButtonHolder(&Window{(*C.GLFWwindow)(unsafe.Pointer(window))}, MouseButton(button), Action(action), Mod(mods))
+	fMouseButtonHolder(&Window{(*C.GLFWwindow)(unsafe.Pointer(window))}, MouseButton(button), Action(action), ModifierKey(mods))
 }
 
 //export goCursorPosCB
@@ -265,7 +265,7 @@ func goScrollCB(window unsafe.Pointer, xoff, yoff C.double) {
 
 //export goKeyCB
 func goKeyCB(window unsafe.Pointer, key, scancode, action, mods C.int) {
-	fKeyHolder(&Window{(*C.GLFWwindow)(unsafe.Pointer(window))}, Key(key), int(scancode), Action(action), Mod(mods))
+	fKeyHolder(&Window{(*C.GLFWwindow)(unsafe.Pointer(window))}, Key(key), int(scancode), Action(action), ModifierKey(mods))
 }
 
 //export goCharCB
@@ -344,7 +344,7 @@ func (w *Window) SetCursorPosition(xpos, ypos float64) {
 //fact that the synthetic ones are generated after the window has lost focus,
 //i.e. Focused will be false and the focus callback will have already been
 //called.
-func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, action Action, mods Mod)) {
+func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, action Action, mods ModifierKey)) {
 	fKeyHolder = cbfun
 	C.glfwSetKeyCallbackCB(w.data)
 }
@@ -367,7 +367,7 @@ func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
 //user-generated events by the fact that the synthetic ones are generated after
 //the window has lost focus, i.e. Focused will be false and the focus
 //callback will have already been called.
-func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton, action Action, mod Mod)) {
+func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton, action Action, mod ModifierKey)) {
 	fMouseButtonHolder = cbfun
 	C.glfwSetMouseButtonCallbackCB(w.data)
 }

--- a/input.go
+++ b/input.go
@@ -220,14 +220,11 @@ const (
 	StickyMouseButtons InputMode = C.GLFW_STICKY_MOUSE_BUTTONS //Value can be either 1 or 0
 )
 
-//CursorMode corresponds to a cursor mode.
-type CursorMode int
-
 //Cursor mode values
 const (
-	CursorNormal   CursorMode = C.GLFW_CURSOR_NORMAL
-	CursorHidden   CursorMode = C.GLFW_CURSOR_HIDDEN
-	CursorDisabled CursorMode = C.GLFW_CURSOR_DISABLED
+	CursorNormal   int = C.GLFW_CURSOR_NORMAL
+	CursorHidden   int = C.GLFW_CURSOR_HIDDEN
+	CursorDisabled int = C.GLFW_CURSOR_DISABLED
 )
 
 var (

--- a/input.go
+++ b/input.go
@@ -11,7 +11,10 @@ package glfw3
 //unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
 import "C"
 
-import "unsafe"
+import (
+	"errors"
+	"unsafe"
+)
 
 //Joystick corresponds to a joystick.
 type Joystick int
@@ -401,34 +404,45 @@ func JoystickPresent(joy Joystick) bool {
 }
 
 //GetJoystickAxes returns a slice of axis values.
-func GetJoystickAxes(joy Joystick) []float32 {
+func GetJoystickAxes(joy Joystick) ([]float32, error) {
 	var length int
 
 	axis := C.glfwGetJoystickAxes(C.int(joy), (*C.int)(unsafe.Pointer(&length)))
-	a := make([]float32, length)
+	if axis == nil {
+		return nil, errors.New("Joystick is not present.")
+	}
 
+	a := make([]float32, length)
 	for i := 0; i < length; i++ {
 		a[i] = float32(C.GetAxisAtIndex(axis, C.int(i)))
 	}
 
-	return a
+	return a, nil
 }
 
 //GetJoystickButtons returns a slice of button values.
-func GetJoystickButtons(joy Joystick) []byte {
+func GetJoystickButtons(joy Joystick) ([]byte, error) {
 	var length int
 
 	buttons := C.glfwGetJoystickButtons(C.int(joy), (*C.int)(unsafe.Pointer(&length)))
-	b := make([]byte, length)
+	if buttons == nil {
+		return nil, errors.New("Joystick is not present.")
+	}
 
+	b := make([]byte, length)
 	for i := 0; i < length; i++ {
 		b[i] = byte(C.GetButtonsAtIndex(buttons, C.int(i)))
 	}
 
-	return b
+	return b, nil
 }
 
 //GetJoystickName returns the name, encoded as UTF-8, of the specified joystick.
-func GetJoystickName(joy Joystick) string {
-	return C.GoString(C.glfwGetJoystickName(C.int(joy)))
+func GetJoystickName(joy Joystick) (string, error) {
+	jn := C.glfwGetJoystickName(C.int(joy))
+	if jn == nil {
+		return "", errors.New("Joystick is not present.")
+	}
+
+	return C.GoString(jn), nil
 }

--- a/input.go
+++ b/input.go
@@ -47,6 +47,7 @@ type Key int
 //but re-arranged to map to 7-bit ASCII for printable keys (function keys are
 //put in the 256+ range).
 const (
+	KeyUnknown      Key = C.GLFW_KEY_UNKNOWN
 	KeySpace        Key = C.GLFW_KEY_SPACE
 	KeyApostrophe   Key = C.GLFW_KEY_APOSTROPHE
 	KeyComma        Key = C.GLFW_KEY_COMMA

--- a/monitor.go
+++ b/monitor.go
@@ -163,7 +163,7 @@ func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 	if rampC == nil {
 		return nil, errors.New("Can't get the gamma ramp.")
 	}
-	
+
 	length := int(rampC.size)
 	ramp.Red = make([]uint16, length)
 	ramp.Green = make([]uint16, length)

--- a/monitor.go
+++ b/monitor.go
@@ -111,8 +111,12 @@ func (m *Monitor) GetName() string {
 //currently set callback. This is called when a monitor is connected to or
 //disconnected from the system.
 func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
-	fMonitorHolder = cbfun
-	C.glfwSetMonitorCallbackCB()
+	if cbfun == nil {
+		C.glfwSetMonitorCallback(nil)
+	} else {
+		fMonitorHolder = cbfun
+		C.glfwSetMonitorCallbackCB()
+	}
 }
 
 //GetVideoModes returns an array of all video modes supported by the monitor.

--- a/window.go
+++ b/window.go
@@ -368,23 +368,35 @@ func (w *Window) GetUserPointer() unsafe.Pointer {
 //when the window is moved. The callback is provided with the screen position
 //of the upper-left corner of the client area of the window.
 func (w *Window) SetPositionCallback(cbfun func(w *Window, xpos int, ypos int)) {
-	fWindowPosHolder = cbfun
-	C.glfwSetWindowPosCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowPosCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowPosHolder = cbfun
+		C.glfwSetWindowPosCallbackCB(w.data)
+	}
 }
 
 //SetSizeCallback sets the size callback of the window, which is called when
 //the window is resized. The callback is provided with the size, in screen
 //coordinates, of the client area of the window.
 func (w *Window) SetSizeCallback(cbfun func(w *Window, width int, height int)) {
-	fWindowSizeHolder = cbfun
-	C.glfwSetWindowSizeCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowSizeCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowSizeHolder = cbfun
+		C.glfwSetWindowSizeCallbackCB(w.data)
+	}
 }
 
 //SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
 //window, which is called when the framebuffer of the specified window is resized.
 func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, height int)) {
-	fFramebufferSizeHolder = cbfun
-	C.glfwSetFramebufferSizeCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetFramebufferSizeCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fFramebufferSizeHolder = cbfun
+		C.glfwSetFramebufferSizeCallbackCB(w.data)
+	}
 }
 
 //SetCloseCallback sets the close callback of the window, which is called when
@@ -397,8 +409,12 @@ func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, hei
 //Mac OS X: Selecting Quit from the application menu will trigger the close
 //callback for all windows.
 func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
-	fWindowCloseHolder = cbfun
-	C.glfwSetWindowCloseCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowCloseCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowCloseHolder = cbfun
+		C.glfwSetWindowCloseCallbackCB(w.data)
+	}
 }
 
 //SetRefreshCallback sets the refresh callback of the window, which
@@ -409,8 +425,12 @@ func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
 //contents are saved off-screen, this callback may be called only very
 //infrequently or never at all.
 func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
-	fWindowRefreshHolder = cbfun
-	C.glfwSetWindowRefreshCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowRefreshCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowRefreshHolder = cbfun
+		C.glfwSetWindowRefreshCallbackCB(w.data)
+	}
 }
 
 //SetFocusCallback sets the focus callback of the window, which is called when
@@ -420,15 +440,23 @@ func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
 //and mouse button release events will be generated for all such that had been
 //pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
 func (w *Window) SetFocusCallback(cbfun func(w *Window, focused bool)) {
-	fWindowFocusHolder = cbfun
-	C.glfwSetWindowFocusCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowFocusCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowFocusHolder = cbfun
+		C.glfwSetWindowFocusCallbackCB(w.data)
+	}
 }
 
 //SetIconifyCallback sets the iconification callback of the window, which is
 //called when the window is iconified or restored.
 func (w *Window) SetIconifyCallback(cbfun func(w *Window, iconified bool)) {
-	fWindowIconifyHolder = cbfun
-	C.glfwSetWindowIconifyCallbackCB(w.data)
+	if cbfun == nil {
+		C.glfwSetWindowIconifyCallback((*C.GLFWwindow)(unsafe.Pointer(w.data)), nil)
+	} else {
+		fWindowIconifyHolder = cbfun
+		C.glfwSetWindowIconifyCallbackCB(w.data)
+	}
 }
 
 //PollEvents processes only those events that have already been received and

--- a/window.go
+++ b/window.go
@@ -61,33 +61,30 @@ const (
 	SrgbCapable     Hint = C.GLFW_SRGB_CAPABLE     //Specifies whether the framebuffer should be sRGB capable.
 )
 
-//HintValue corresponds to a hint value.
-type HintValue int
-
 //Values for the ClientApi hint.
 const (
-	OpenglApi   HintValue = C.GLFW_OPENGL_API
-	OpenglEsApi HintValue = C.GLFW_OPENGL_ES_API
+	OpenglApi   int = C.GLFW_OPENGL_API
+	OpenglEsApi int = C.GLFW_OPENGL_ES_API
 )
 
 //Values for the ContextRobustness hint.
 const (
-	NoRobustness        HintValue = C.GLFW_NO_ROBUSTNESS
-	NoResetNotification HintValue = C.GLFW_NO_RESET_NOTIFICATION
-	LoseContextOnReset  HintValue = C.GLFW_LOSE_CONTEXT_ON_RESET
+	NoRobustness        int = C.GLFW_NO_ROBUSTNESS
+	NoResetNotification int = C.GLFW_NO_RESET_NOTIFICATION
+	LoseContextOnReset  int = C.GLFW_LOSE_CONTEXT_ON_RESET
 )
 
 //Values for the OpenglProfile hint.
 const (
-	OpenglAnyProfile    HintValue = C.GLFW_OPENGL_ANY_PROFILE
-	OpenglCoreProfile   HintValue = C.GLFW_OPENGL_CORE_PROFILE
-	OpenglCompatProfile HintValue = C.GLFW_OPENGL_COMPAT_PROFILE
+	OpenglAnyProfile    int = C.GLFW_OPENGL_ANY_PROFILE
+	OpenglCoreProfile   int = C.GLFW_OPENGL_CORE_PROFILE
+	OpenglCompatProfile int = C.GLFW_OPENGL_COMPAT_PROFILE
 )
 
 //TRUE and FALSE values to use with hints.
 const (
-	True  HintValue = C.GL_TRUE
-	False HintValue = C.GL_FALSE
+	True  int = C.GL_TRUE
+	False int = C.GL_FALSE
 )
 
 type Window struct {
@@ -155,7 +152,7 @@ func DefaultWindowHints() {
 //Hint function sets hints for the next call to CreateWindow. The hints,
 //once set, retain their values until changed by a call to Hint or
 //DefaultHints, or until the library is terminated with Terminate.
-func WindowHint(target Hint, hint HintValue) {
+func WindowHint(target Hint, hint int) {
 	C.glfwWindowHint(C.int(target), C.int(hint))
 }
 
@@ -351,8 +348,8 @@ func (w *Window) GetMonitor() (*Monitor, error) {
 
 //GetAttribute returns an attribute of the window. There are many attributes,
 //some related to the window and others to its context.
-func (w *Window) GetAttribute(attrib Hint) HintValue {
-	return HintValue(C.glfwGetWindowAttrib(w.data, C.int(attrib)))
+func (w *Window) GetAttribute(attrib Hint) int {
+	return int(C.glfwGetWindowAttrib(w.data, C.int(attrib)))
 }
 
 //SetUserPointer sets the user-defined pointer of the window. The current value


### PR DESCRIPTION
- Some enum types are replaced with plain "int" because they were cross used and hard to rename in a manner that make sense.
- # 27 is updated to return error for some functions but not callbacks. I've looked and callback functions does not have error checking in GLFW as well except IS_GLFW_INIT which can be cought with error callback so they don't need to be returned. In the future #8 will affect this too.
- Now you can pass nil to callback functions to unset the callbacks. Before it would give an error because go would try to dereference a nil pointer.
