### PR TITLE
Adjusted link flags for Mac OS X

### DIFF
--- a/glfw.go
+++ b/glfw.go
@@ -7,7 +7,7 @@ package glfw3
 
 //#cgo windows LDFLAGS: -lglfw3dll -lopengl32 -lgdi32
 //#cgo linux LDFLAGS: -lglfw
-//#cgo darwin LDFLAGS: -lglfw
+//#cgo darwin LDFLAGS: -lglfw3 -framework Cocoa -framework OpenGL -framework IOKit
 //#ifdef _WIN32
 //  #define GLFW_DLL
 //#endif


### PR DESCRIPTION
First, glfw3 builds as libglfw3 by default, so we link against that.
Then, we have to link a few frameworks, to get rid of missing symbols.

glfw3 homebrew PR pending: https://github.com/mxcl/homebrew/pull/21620

FWIW, the glfw -> glfw3 move is probably valid for Linux too, but I can't test that right now, so not included.
