### PR TITLE
Fixed compilation error on darwin

### DIFF
--- a/glfw.go
+++ b/glfw.go
@@ -1,13 +1,11 @@
 package glfw3
 
-// Not sure about the darwin flag
-
 // Windows users: If you download the GLFW 64-bit binaries, when you copy over the contents of the lib folder make sure to rename
 // glfw3dll.a to libglfw3dll.a, it doesn't work otherwise.
 
 //#cgo windows LDFLAGS: -lglfw3dll -lopengl32 -lgdi32
 //#cgo linux LDFLAGS: -lglfw
-//#cgo darwin LDFLAGS: -lglfw3 -framework Cocoa -framework OpenGL -framework IOKit
+//#cgo darwin LDFLAGS: -lglfw -framework Cocoa -framework OpenGL -framework IOKit
 //#ifdef _WIN32
 //  #define GLFW_DLL
 //#endif


### PR DESCRIPTION
Darwin uses shared libs with version numbers, ie libglfw.3.0.dylib, not glfw3. 
