### PR TITLE
Fix window callbacks to be per-context.

### DIFF
--- a/context.go
+++ b/context.go
@@ -25,11 +25,10 @@ func DetachCurrentContext() {
 //GetCurrentContext returns the window whose context is current.
 func GetCurrentContext() (*Window, error) {
 	w := C.glfwGetCurrentContext()
-
 	if w == nil {
 		return nil, errors.New("Current context is not set.")
 	}
-	return &Window{w}, nil
+	return windows.get(w), nil
 }
 
 //SwapBuffers swaps the front and back buffers of the window. If the

--- a/input.go
+++ b/input.go
@@ -228,44 +228,41 @@ const (
 	CursorDisabled int = C.GLFW_CURSOR_DISABLED
 )
 
-var (
-	fMouseButtonHolder func(w *Window, button MouseButton, action Action, mod ModifierKey)
-	fCursorPosHolder   func(w *Window, xpos float64, ypos float64)
-	fCursorEnterHolder func(w *Window, entered bool)
-	fScrollHolder      func(w *Window, xoff float64, yoff float64)
-	fKeyHolder         func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
-	fCharHolder        func(w *Window, char uint)
-)
-
 //export goMouseButtonCB
 func goMouseButtonCB(window unsafe.Pointer, button, action, mods C.int) {
-	fMouseButtonHolder(&Window{(*C.GLFWwindow)(window)}, MouseButton(button), Action(action), ModifierKey(mods))
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
+	w.fMouseButtonHolder(w, MouseButton(button), Action(action), ModifierKey(mods))
 }
 
 //export goCursorPosCB
 func goCursorPosCB(window unsafe.Pointer, xpos, ypos C.float) {
-	fCursorPosHolder(&Window{(*C.GLFWwindow)(window)}, float64(xpos), float64(ypos))
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
+	w.fCursorPosHolder(w, float64(xpos), float64(ypos))
 }
 
 //export goCursorEnterCB
 func goCursorEnterCB(window unsafe.Pointer, entered C.int) {
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
 	hasEntered := glfwbool(entered)
-	fCursorEnterHolder(&Window{(*C.GLFWwindow)(window)}, hasEntered)
+	w.fCursorEnterHolder(w, hasEntered)
 }
 
 //export goScrollCB
 func goScrollCB(window unsafe.Pointer, xoff, yoff C.float) {
-	fScrollHolder(&Window{(*C.GLFWwindow)(window)}, float64(xoff), float64(yoff))
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
+	w.fScrollHolder(w, float64(xoff), float64(yoff))
 }
 
 //export goKeyCB
 func goKeyCB(window unsafe.Pointer, key, scancode, action, mods C.int) {
-	fKeyHolder(&Window{(*C.GLFWwindow)(window)}, Key(key), int(scancode), Action(action), ModifierKey(mods))
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
+	w.fKeyHolder(w, Key(key), int(scancode), Action(action), ModifierKey(mods))
 }
 
 //export goCharCB
 func goCharCB(window unsafe.Pointer, character C.uint) {
-	fCharHolder(&Window{(*C.GLFWwindow)(window)}, uint(character))
+	w := windows.get((*C.GLFWwindow)(unsafe.Pointer(window)))
+	w.fCharHolder(w, uint(character))
 }
 
 //GetInputMode returns the value of an input option of the window.
@@ -343,7 +340,7 @@ func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, act
 	if cbfun == nil {
 		C.glfwSetKeyCallback(w.data, nil)
 	} else {
-		fKeyHolder = cbfun
+		w.fKeyHolder = cbfun
 		C.glfwSetKeyCallbackCB(w.data)
 	}
 }
@@ -357,7 +354,7 @@ func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
 	if cbfun == nil {
 		C.glfwSetCharCallback(w.data, nil)
 	} else {
-		fCharHolder = cbfun
+		w.fCharHolder = cbfun
 		C.glfwSetCharCallbackCB(w.data)
 	}
 }
@@ -374,7 +371,7 @@ func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton
 	if cbfun == nil {
 		C.glfwSetMouseButtonCallback(w.data, nil)
 	} else {
-		fMouseButtonHolder = cbfun
+		w.fMouseButtonHolder = cbfun
 		C.glfwSetMouseButtonCallbackCB(w.data)
 	}
 }
@@ -386,7 +383,7 @@ func (w *Window) SetCursorPositionCallback(cbfun func(w *Window, xpos float64, y
 	if cbfun == nil {
 		C.glfwSetCursorPosCallback(w.data, nil)
 	} else {
-		fCursorPosHolder = cbfun
+		w.fCursorPosHolder = cbfun
 		C.glfwSetCursorPosCallbackCB(w.data)
 	}
 }
@@ -397,7 +394,7 @@ func (w *Window) SetCursorEnterCallback(cbfun func(w *Window, entered bool)) {
 	if cbfun == nil {
 		C.glfwSetCursorEnterCallback(w.data, nil)
 	} else {
-		fCursorEnterHolder = cbfun
+		w.fCursorEnterHolder = cbfun
 		C.glfwSetCursorEnterCallbackCB(w.data)
 	}
 }
@@ -408,7 +405,7 @@ func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff floa
 	if cbfun == nil {
 		C.glfwSetScrollCallback(w.data, nil)
 	} else {
-		fScrollHolder = cbfun
+		w.fScrollHolder = cbfun
 		C.glfwSetScrollCallbackCB(w.data)
 	}
 }


### PR DESCRIPTION
Per-window (or context) callbacks were using globally defined function
vars, which caused unexpected behavior given the API and documentation.
This changes the callbacks to behave as expected by giving each window
callback vars, and using a global map[_C.GLFWwindow]_Window.

Fixes #53.
