### PR TITLE
Remove reference to a go1.1.2-only issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Remarks
 * Mingw64 users should rename ***glfw3dll.a*** to ***libglfw3dll.a***.
 * In Windows and Linux, if you compile GLFW yourself, use <code>-DBUILD_SHARED_LIBS=on</code> with cmake in order to build the dynamic libraries.
 * Some functions -which are marked in the documentation- can be called only from the main thread. Click [here](https://code.google.com/p/go-wiki/wiki/LockOSThread) for how.
-* In Mac OS, due to a bug in official Go packages, it's recommended to install Go and GLFW via [Homebrew](http://brew.sh/).
+* In OS X, you can install Go and GLFW via [Homebrew](http://brew.sh/).
 
 ```
 $ brew install go


### PR DESCRIPTION
"due to a bug in official Go packages" was affecting the installer for go1.1.2; it's no longer the case for go1.2, the current stable released version.
Change "Mac OS" to "OS X".
