### PR TITLE
Add glfwPostEmptyEvent() support (for GLFW 3.1).

### DIFF
--- a/window.go
+++ b/window.go
@@ -547,3 +547,15 @@ func PollEvents() {
 func WaitEvents() {
 	C.glfwWaitEvents()
 }
+
+//PostEmptyEvent posts an empty event from the current thread to the main
+//thread event queue, causing WaitEvents to return.
+//
+//If no windows exist, this function returns immediately.  For
+//synchronization of threads in applications that do not create windows, use
+//your threading library of choice.
+//
+//This function may be called from secondary threads.
+func PostEmptyEvent() {
+	C.glfwPostEmptyEvent()
+}


### PR DESCRIPTION
GLFW 3 has just recently merged a new function `glfwPostEmptyEvent()` into master (what will eventually be released as GLFW 3.1), see https://github.com/glfw/glfw/issues/218#issuecomment-37137200.

This PR adds support for it. It should be merged when GLFW 3.1 is released, because it's incompatible with current GLFW 3.0.4.

I tested that it works [here](https://gist.github.com/shurcooL/5816852/revisions).
