### PR TITLE
Add glfwSetDropCallback() support (for GLFW 3.1).

### DIFF
--- a/input.c
+++ b/input.c
@@ -24,6 +24,10 @@ void glfwCharCB(GLFWwindow* window, unsigned int character) {
 	goCharCB(window, character);
 }
 
+void glfwDropCB(GLFWwindow* window, int count, const char **names) {
+	goDropCB(window, count, (char**)names);
+}
+
 void glfwSetKeyCallbackCB(GLFWwindow *window) {
 	glfwSetKeyCallback(window, glfwKeyCB);
 }
@@ -46,6 +50,10 @@ void glfwSetCursorEnterCallbackCB(GLFWwindow *window) {
 
 void glfwSetScrollCallbackCB(GLFWwindow *window) {
 	glfwSetScrollCallback(window, glfwScrollCB);
+}
+
+void glfwSetDropCallbackCB(GLFWwindow *window) {
+	glfwSetDropCallback(window, glfwDropCB);
 }
 
 float GetAxisAtIndex(float *axis, int i) {

--- a/input.go
+++ b/input.go
@@ -7,6 +7,7 @@ package glfw3
 //void glfwSetCursorPosCallbackCB(GLFWwindow *window);
 //void glfwSetCursorEnterCallbackCB(GLFWwindow *window);
 //void glfwSetScrollCallbackCB(GLFWwindow *window);
+//void glfwSetDropCallbackCB(GLFWwindow *window);
 //float GetAxisAtIndex(float *axis, int i);
 //unsigned char GetButtonsAtIndex(unsigned char *buttons, int i);
 import "C"
@@ -265,6 +266,18 @@ func goCharCB(window unsafe.Pointer, character C.uint) {
 	w.fCharHolder(w, uint(character))
 }
 
+//export goDropCB
+func goDropCB(window unsafe.Pointer, count C.int, names **C.char) { // TODO: The types of name can be `**C.char` or `unsafe.Pointer`, use whichever is better.
+	w := windows.get((*C.GLFWwindow)(window))
+	namesSlice := make([]string, int(count)) //                                                       // TODO: Make this better. This part is unfinished, hacky, probably not correct, and not idiomatic.
+	for i := 0; i < int(count); i++ {        //                                                       // TODO: Make this better. It should be cleaned up and vetted.
+		var x *C.char                                                                                 // TODO: Make this better.
+		p := (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(names)) + uintptr(i)*unsafe.Sizeof(x))) // TODO: Make this better.
+		namesSlice[i] = C.GoString(*p)                                                                // TODO: Make this better.
+	}
+	w.fDropHolder(w, namesSlice)
+}
+
 //GetInputMode returns the value of an input option of the window.
 func (w *Window) GetInputMode(mode InputMode) int {
 	return int(C.glfwGetInputMode(w.data, C.int(mode)))
@@ -407,6 +420,17 @@ func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff floa
 	} else {
 		w.fScrollHolder = cbfun
 		C.glfwSetScrollCallbackCB(w.data)
+	}
+}
+
+//SetDropCallback sets the drop callback which is called when an object
+//is dropped over the window.
+func (w *Window) SetDropCallback(cbfun func(w *Window, names []string)) {
+	if cbfun == nil {
+		C.glfwSetDropCallback(w.data, nil)
+	} else {
+		w.fDropHolder = cbfun
+		C.glfwSetDropCallbackCB(w.data)
 	}
 }
 

--- a/window.go
+++ b/window.go
@@ -134,6 +134,7 @@ type Window struct {
 	fScrollHolder      func(w *Window, xoff float64, yoff float64)
 	fKeyHolder         func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
 	fCharHolder        func(w *Window, char uint)
+	fDropHolder        func(w *Window, names []string)
 }
 
 //export goWindowPosCB


### PR DESCRIPTION
The cgo to Go type conversion in `goDropCB` is unfinished and needs to be improved. Help is highly welcome.

It seems to work on OS X 10.9 (but this doesn't guarantee that the unsafe pointer manipulation is fully correct).

The TODOs should be taken care of and this can be merged when GLFW 3.1 is released:
- [ ] Take care of TODOs for `goDropCB`.
- [x] Verify that UTF-8 encoded C strings are properly converted to Go strings.
