### PR TITLE
Fix compilation on Debian (with manual GLFW3 installation)

### DIFF
--- a/glfw.go
+++ b/glfw.go
@@ -6,7 +6,8 @@ package glfw3
 // glfw3dll.a to libglfw3dll.a, it doesn't work otherwise.
 
 //#cgo windows LDFLAGS: -lglfw3dll -lopengl32 -lgdi32
-//#cgo linux LDFLAGS: -lglfw
+//#cgo linux LDFLAGS: -lm
+//#cgo linux pkg-config: gl glfw3 x11 xxf86vm glib-2.0 xrandr xi
 //#cgo darwin LDFLAGS: -lglfw3 -framework Cocoa -framework OpenGL -framework IOKit -framework CoreVideo
 //#ifdef _WIN32
 //  #define GLFW_DLL


### PR DESCRIPTION
glfw3 does not install on Debian Jessie (testing) without these changes.
