### PR TITLE
Improve documentation style slightly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Remarks
 
 * Mingw64 users should rename ***glfw3dll.a*** to ***libglfw3dll.a***.
 * In Windows and Linux, if you compile GLFW yourself, use <code>-DBUILD_SHARED_LIBS=on</code> with cmake in order to build the dynamic libraries.
-* Some functions -which are marked in the documentation- can be called only from the main thread. Click [here](https://code.google.com/p/go-wiki/wiki/LockOSThread) for how.
+* Some functions -which are marked in the documentation- can be called only from the main thread. You may need to use [runtime.LockOSThread()](http://godoc.org/runtime#LockOSThread).
 * In OS X, you can install Go and GLFW via [Homebrew](http://brew.sh/).
 
 ```
@@ -45,7 +45,7 @@ func main() {
 	window.MakeContextCurrent()
 
 	for !window.ShouldClose() {
-		//Do OpenGL stuff
+		// Do OpenGL stuff
 		window.SwapBuffers()
 		glfw.PollEvents()
 	}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Remarks
 
 * Mingw64 users should rename ***glfw3dll.a*** to ***libglfw3dll.a***.
 * In Windows and Linux, if you compile GLFW yourself, use <code>-DBUILD_SHARED_LIBS=on</code> with cmake in order to build the dynamic libraries.
-* Some functions -which are marked in the documentation- can be called only from the main thread. You may need to use [runtime.LockOSThread()](http://godoc.org/runtime#LockOSThread).
+* Some functions -which are marked in the documentation- can be called only from the main thread. You need to use [runtime.LockOSThread()](http://godoc.org/runtime#LockOSThread) to arrange that main() runs on main thread.
 * In OS X, you can install Go and GLFW via [Homebrew](http://brew.sh/).
 
 ```
@@ -27,8 +27,14 @@ Example
 package main
 
 import (
+	"runtime"
+
 	glfw "github.com/go-gl/glfw3"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 func main() {
 	err := glfw.Init()

--- a/clipboard.go
+++ b/clipboard.go
@@ -8,22 +8,20 @@ import (
 	"unsafe"
 )
 
-//SetClipboardString sets the system clipboard to the specified UTF-8 encoded
-//string.
+// SetClipboardString sets the system clipboard to the specified UTF-8 encoded
+// string.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) SetClipboardString(str string) {
 	cp := C.CString(str)
 	defer C.free(unsafe.Pointer(cp))
 	C.glfwSetClipboardString(w.data, cp)
 }
 
-//GetClipboardString returns the contents of the system clipboard, if it
-//contains or is convertible to a UTF-8 encoded string.
+// GetClipboardString returns the contents of the system clipboard, if it
+// contains or is convertible to a UTF-8 encoded string.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) GetClipboardString() (string, error) {
 	cs := C.glfwGetClipboardString(w.data)
 	if cs == nil {

--- a/context.go
+++ b/context.go
@@ -8,20 +8,20 @@ import (
 	"unsafe"
 )
 
-//MakeContextCurrent makes the context of the window current.
-//Originally GLFW 3 passes a null pointer to detach the context.
-//But since we're using receievers, DetachCurrentContext should
-//be used instead.
+// MakeContextCurrent makes the context of the window current.
+// Originally GLFW 3 passes a null pointer to detach the context.
+// But since we're using receievers, DetachCurrentContext should
+// be used instead.
 func (w *Window) MakeContextCurrent() {
 	C.glfwMakeContextCurrent(w.data)
 }
 
-//DetachCurrentContext detaches the current context.
+// DetachCurrentContext detaches the current context.
 func DetachCurrentContext() {
 	C.glfwMakeContextCurrent(nil)
 }
 
-//GetCurrentContext returns the window whose context is current.
+// GetCurrentContext returns the window whose context is current.
 func GetCurrentContext() *Window {
 	w := C.glfwGetCurrentContext()
 	if w == nil {
@@ -30,39 +30,39 @@ func GetCurrentContext() *Window {
 	return windows.get(w)
 }
 
-//SwapBuffers swaps the front and back buffers of the window. If the
-//swap interval is greater than zero, the GPU driver waits the specified number
-//of screen updates before swapping the buffers.
+// SwapBuffers swaps the front and back buffers of the window. If the
+// swap interval is greater than zero, the GPU driver waits the specified number
+// of screen updates before swapping the buffers.
 func (w *Window) SwapBuffers() {
 	C.glfwSwapBuffers(w.data)
 }
 
-//SwapInterval sets the swap interval for the current context, i.e. the number
-//of screen updates to wait before swapping the buffers of a window and
-//returning from SwapBuffers. This is sometimes called
-//'vertical synchronization', 'vertical retrace synchronization' or 'vsync'.
+// SwapInterval sets the swap interval for the current context, i.e. the number
+// of screen updates to wait before swapping the buffers of a window and
+// returning from SwapBuffers. This is sometimes called
+// 'vertical synchronization', 'vertical retrace synchronization' or 'vsync'.
 //
-//Contexts that support either of the WGL_EXT_swap_control_tear and
-//GLX_EXT_swap_control_tear extensions also accept negative swap intervals,
-//which allow the driver to swap even if a frame arrives a little bit late.
-//You can check for the presence of these extensions using
-//ExtensionSupported. For more information about swap tearing,
-//see the extension specifications.
+// Contexts that support either of the WGL_EXT_swap_control_tear and
+// GLX_EXT_swap_control_tear extensions also accept negative swap intervals,
+// which allow the driver to swap even if a frame arrives a little bit late.
+// You can check for the presence of these extensions using
+// ExtensionSupported. For more information about swap tearing,
+// see the extension specifications.
 //
-//Some GPU drivers do not honor the requested swap interval, either because of
-//user settings that override the request or due to bugs in the driver.
+// Some GPU drivers do not honor the requested swap interval, either because of
+// user settings that override the request or due to bugs in the driver.
 func SwapInterval(interval int) {
 	C.glfwSwapInterval(C.int(interval))
 }
 
-//ExtensionSupported returns whether the specified OpenGL or context creation
-//API extension is supported by the current context. For example, on Windows
-//both the OpenGL and WGL extension strings are checked.
+// ExtensionSupported returns whether the specified OpenGL or context creation
+// API extension is supported by the current context. For example, on Windows
+// both the OpenGL and WGL extension strings are checked.
 //
-//As this functions searches one or more extension strings on each call, it is
-//recommended that you cache its results if it's going to be used frequently.
-//The extension strings will not change during the lifetime of a context, so
-//there is no danger in doing this.
+// As this functions searches one or more extension strings on each call, it is
+// recommended that you cache its results if it's going to be used frequently.
+// The extension strings will not change during the lifetime of a context, so
+// there is no danger in doing this.
 func ExtensionSupported(extension string) bool {
 	e := C.CString(extension)
 	defer C.free(unsafe.Pointer(e))

--- a/error.go
+++ b/error.go
@@ -8,29 +8,29 @@ import (
 	"fmt"
 )
 
-//ErrorCode corresponds to an error code.
+// ErrorCode corresponds to an error code.
 type ErrorCode int
 
-//Error codes.
+// Error codes.
 const (
-	NotInitialized     ErrorCode = C.GLFW_NOT_INITIALIZED     //GLFW has not been initialized.
-	NoCurrentContext   ErrorCode = C.GLFW_NO_CURRENT_CONTEXT  //No context is current.
-	InvalidEnum        ErrorCode = C.GLFW_INVALID_ENUM        //One of the enum parameters for the function was given an invalid enum.
-	InvalidValue       ErrorCode = C.GLFW_INVALID_VALUE       //One of the parameters for the function was given an invalid value.
-	OutOfMemory        ErrorCode = C.GLFW_OUT_OF_MEMORY       //A memory allocation failed.
-	ApiUnavailable     ErrorCode = C.GLFW_API_UNAVAILABLE     //GLFW could not find support for the requested client API on the system.
-	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE //The requested client API version is not available.
-	PlatformError      ErrorCode = C.GLFW_PLATFORM_ERROR      //A platform-specific error occurred that does not match any of the more specific categories.
-	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  //The clipboard did not contain data in the requested format.
+	NotInitialized     ErrorCode = C.GLFW_NOT_INITIALIZED     // GLFW has not been initialized.
+	NoCurrentContext   ErrorCode = C.GLFW_NO_CURRENT_CONTEXT  // No context is current.
+	InvalidEnum        ErrorCode = C.GLFW_INVALID_ENUM        // One of the enum parameters for the function was given an invalid enum.
+	InvalidValue       ErrorCode = C.GLFW_INVALID_VALUE       // One of the parameters for the function was given an invalid value.
+	OutOfMemory        ErrorCode = C.GLFW_OUT_OF_MEMORY       // A memory allocation failed.
+	ApiUnavailable     ErrorCode = C.GLFW_API_UNAVAILABLE     // GLFW could not find support for the requested client API on the system.
+	VersionUnavailable ErrorCode = C.GLFW_VERSION_UNAVAILABLE // The requested client API version is not available.
+	PlatformError      ErrorCode = C.GLFW_PLATFORM_ERROR      // A platform-specific error occurred that does not match any of the more specific categories.
+	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  // The clipboard did not contain data in the requested format.
 )
 
-//GlfwError holds error code and description.
+// GlfwError holds error code and description.
 type GlfwError struct {
 	Code ErrorCode
 	Desc string
 }
 
-//Holds the value of the last error
+// Holds the value of the last error
 var lastError = make(chan *GlfwError, 1)
 
 //export goErrorCB
@@ -38,12 +38,12 @@ func goErrorCB(code C.int, desc *C.char) {
 	lastError <- &GlfwError{ErrorCode(code), C.GoString(desc)}
 }
 
-//Error prints the error code and description in a readable format.
+// Error prints the error code and description in a readable format.
 func (e *GlfwError) Error() string {
 	return fmt.Sprintf("Error %d: %s", e.Code, e.Desc)
 }
 
-//Set the glfw callback internally
+// Set the glfw callback internally
 func init() {
 	C.glfwSetErrorCallbackCB()
 }

--- a/glfw.go
+++ b/glfw.go
@@ -1,7 +1,5 @@
 package glfw3
 
-// Not sure about the darwin flag
-
 // Windows users: If you download the GLFW 64-bit binaries, when you copy over the contents of the lib folder make sure to rename
 // glfw3dll.a to libglfw3dll.a, it doesn't work otherwise.
 
@@ -15,31 +13,30 @@ package glfw3
 import "C"
 
 const (
-	VersionMajor    = C.GLFW_VERSION_MAJOR    //This is incremented when the API is changed in non-compatible ways.
-	VersionMinor    = C.GLFW_VERSION_MINOR    //This is incremented when features are added to the API but it remains backward-compatible.
-	VersionRevision = C.GLFW_VERSION_REVISION //This is incremented when a bug fix release is made that does not contain any API changes.
+	VersionMajor    = C.GLFW_VERSION_MAJOR    // This is incremented when the API is changed in non-compatible ways.
+	VersionMinor    = C.GLFW_VERSION_MINOR    // This is incremented when features are added to the API but it remains backward-compatible.
+	VersionRevision = C.GLFW_VERSION_REVISION // This is incremented when a bug fix release is made that does not contain any API changes.
 )
 
-//Init initializes the GLFW library. Before most GLFW functions can be used,
-//GLFW must be initialized, and before a program terminates GLFW should be
-//terminated in order to free any resources allocated during or after
-//initialization.
+// Init initializes the GLFW library. Before most GLFW functions can be used,
+// GLFW must be initialized, and before a program terminates GLFW should be
+// terminated in order to free any resources allocated during or after
+// initialization.
 //
-//If this function fails, it calls Terminate before returning. If it succeeds,
-//you should call Terminate before the program exits.
+// If this function fails, it calls Terminate before returning. If it succeeds,
+// you should call Terminate before the program exits.
 //
-//Additional calls to this function after successful initialization but before
-//termination will succeed but will do nothing.
+// Additional calls to this function after successful initialization but before
+// termination will succeed but will do nothing.
 //
-//This function may take several seconds to complete on some systems, while on
-//other systems it may take only a fraction of a second to complete.
+// This function may take several seconds to complete on some systems, while on
+// other systems it may take only a fraction of a second to complete.
 //
-//On Mac OS X, this function will change the current directory of the
-//application to the Contents/Resources subdirectory of the application's
-//bundle, if present.
+// On Mac OS X, this function will change the current directory of the
+// application to the Contents/Resources subdirectory of the application's
+// bundle, if present.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func Init() error {
 	if glfwbool(C.glfwInit()) {
 		return nil
@@ -47,26 +44,25 @@ func Init() error {
 	return <-lastError
 }
 
-//Terminate destroys all remaining windows, frees any allocated resources and
-//sets the library to an uninitialized state. Once this is called, you must
-//again call Init successfully before you will be able to use most GLFW
-//functions.
+// Terminate destroys all remaining windows, frees any allocated resources and
+// sets the library to an uninitialized state. Once this is called, you must
+// again call Init successfully before you will be able to use most GLFW
+// functions.
 //
-//If GLFW has been successfully initialized, this function should be called
-//before the program exits. If initialization fails, there is no need to call
-//this function, as it is called by Init before it returns failure.
+// If GLFW has been successfully initialized, this function should be called
+// before the program exits. If initialization fails, there is no need to call
+// this function, as it is called by Init before it returns failure.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func Terminate() {
 	C.glfwTerminate()
 }
 
-//GetVersion retrieves the major, minor and revision numbers of the GLFW
-//library. It is intended for when you are using GLFW as a shared library and
-//want to ensure that you are using the minimum required version.
+// GetVersion retrieves the major, minor and revision numbers of the GLFW
+// library. It is intended for when you are using GLFW as a shared library and
+// want to ensure that you are using the minimum required version.
 //
-//This function may be called before Init.
+// This function may be called before Init.
 func GetVersion() (major, minor, revision int) {
 	var (
 		maj C.int
@@ -78,12 +74,12 @@ func GetVersion() (major, minor, revision int) {
 	return int(maj), int(min), int(rev)
 }
 
-//GetVersionString returns a static string generated at compile-time according
-//to which configuration macros were defined. This is intended for use when
-//submitting bug reports, to allow developers to see which code paths are
-//enabled in a binary.
+// GetVersionString returns a static string generated at compile-time according
+// to which configuration macros were defined. This is intended for use when
+// submitting bug reports, to allow developers to see which code paths are
+// enabled in a binary.
 //
-//This function may be called before Init.
+// This function may be called before Init.
 func GetVersionString() string {
 	return C.GoString(C.glfwGetVersionString())
 }

--- a/input.go
+++ b/input.go
@@ -17,10 +17,10 @@ import (
 	"unsafe"
 )
 
-//Joystick corresponds to a joystick.
+// Joystick corresponds to a joystick.
 type Joystick int
 
-//Joystick IDs
+// Joystick IDs
 const (
 	Joystick1    Joystick = C.GLFW_JOYSTICK_1
 	Joystick2    Joystick = C.GLFW_JOYSTICK_2
@@ -41,12 +41,12 @@ const (
 	JoystickLast Joystick = C.GLFW_JOYSTICK_LAST
 )
 
-//Key corresponds to a keyboard key.
+// Key corresponds to a keyboard key.
 type Key int
 
-//These key codes are inspired by the USB HID Usage Tables v1.12 (p. 53-60),
-//but re-arranged to map to 7-bit ASCII for printable keys (function keys are
-//put in the 256+ range).
+// These key codes are inspired by the USB HID Usage Tables v1.12 (p. 53-60),
+// but re-arranged to map to 7-bit ASCII for printable keys (function keys are
+// put in the 256+ range).
 const (
 	KeyUnknown      Key = C.GLFW_KEY_UNKNOWN
 	KeySpace        Key = C.GLFW_KEY_SPACE
@@ -95,7 +95,7 @@ const (
 	KeyZ            Key = C.GLFW_KEY_Z
 	KeyLeftBracket  Key = C.GLFW_KEY_LEFT_BRACKET
 	KeyBackslash    Key = C.GLFW_KEY_BACKSLASH
-	KeyBracket      Key = C.GLFW_KEY_RIGHT_BRACKET //Kept for backward compatbility
+	KeyBracket      Key = C.GLFW_KEY_RIGHT_BRACKET // Kept for backward compatbility
 	KeyRightBracket Key = C.GLFW_KEY_RIGHT_BRACKET
 	KeyGraveAccent  Key = C.GLFW_KEY_GRAVE_ACCENT
 	KeyWorld1       Key = C.GLFW_KEY_WORLD_1
@@ -173,10 +173,10 @@ const (
 	KeyLast         Key = C.GLFW_KEY_LAST
 )
 
-//ModifierKey corresponds to a modifier key.
+// ModifierKey corresponds to a modifier key.
 type ModifierKey int
 
-//Modifier keys
+// Modifier keys
 const (
 	ModShift   ModifierKey = C.GLFW_MOD_SHIFT
 	ModControl ModifierKey = C.GLFW_MOD_CONTROL
@@ -184,10 +184,10 @@ const (
 	ModSuper   ModifierKey = C.GLFW_MOD_SUPER
 )
 
-//MouseButton corresponds to a mouse button.
+// MouseButton corresponds to a mouse button.
 type MouseButton int
 
-//Mouse buttons
+// Mouse buttons
 const (
 	MouseButton1      MouseButton = C.GLFW_MOUSE_BUTTON_1
 	MouseButton2      MouseButton = C.GLFW_MOUSE_BUTTON_2
@@ -203,26 +203,26 @@ const (
 	MouseButtonMiddle MouseButton = C.GLFW_MOUSE_BUTTON_MIDDLE
 )
 
-//Action corresponds to a key or button action.
+// Action corresponds to a key or button action.
 type Action int
 
 const (
-	Release Action = C.GLFW_RELEASE //The key or button was released.
-	Press   Action = C.GLFW_PRESS   //The key or button was pressed.
-	Repeat  Action = C.GLFW_REPEAT  //The key was held down until it repeated.
+	Release Action = C.GLFW_RELEASE // The key or button was released.
+	Press   Action = C.GLFW_PRESS   // The key or button was pressed.
+	Repeat  Action = C.GLFW_REPEAT  // The key was held down until it repeated.
 )
 
-//InputMode corresponds to an input mode.
+// InputMode corresponds to an input mode.
 type InputMode int
 
-//Input modes
+// Input modes
 const (
-	Cursor             InputMode = C.GLFW_CURSOR               //See Cursor mode values
-	StickyKeys         InputMode = C.GLFW_STICKY_KEYS          //Value can be either 1 or 0
-	StickyMouseButtons InputMode = C.GLFW_STICKY_MOUSE_BUTTONS //Value can be either 1 or 0
+	Cursor             InputMode = C.GLFW_CURSOR               // See Cursor mode values
+	StickyKeys         InputMode = C.GLFW_STICKY_KEYS          // Value can be either 1 or 0
+	StickyMouseButtons InputMode = C.GLFW_STICKY_MOUSE_BUTTONS // Value can be either 1 or 0
 )
 
-//Cursor mode values
+// Cursor mode values
 const (
 	CursorNormal   int = C.GLFW_CURSOR_NORMAL
 	CursorHidden   int = C.GLFW_CURSOR_HIDDEN
@@ -284,76 +284,76 @@ func goDropCB(window unsafe.Pointer, count C.int, names **C.char) { // TODO: The
 	w.fDropHolder(w, namesSlice)
 }
 
-//GetInputMode returns the value of an input option of the window.
+// GetInputMode returns the value of an input option of the window.
 func (w *Window) GetInputMode(mode InputMode) int {
 	return int(C.glfwGetInputMode(w.data, C.int(mode)))
 }
 
-//Sets an input option for the window.
+// Sets an input option for the window.
 func (w *Window) SetInputMode(mode InputMode, value int) {
 	C.glfwSetInputMode(w.data, C.int(mode), C.int(value))
 }
 
-//GetKey returns the last reported state of a keyboard key. The returned state
-//is one of Press or Release. The higher-level state Repeat is only reported to
-//the key callback.
+// GetKey returns the last reported state of a keyboard key. The returned state
+// is one of Press or Release. The higher-level state Repeat is only reported to
+// the key callback.
 //
-//If the StickyKeys input mode is enabled, this function returns Press the first
-//time you call this function after a key has been pressed, even if the key has
-//already been released.
+// If the StickyKeys input mode is enabled, this function returns Press the first
+// time you call this function after a key has been pressed, even if the key has
+// already been released.
 //
-//The key functions deal with physical keys, with key tokens named after their
-//use on the standard US keyboard layout. If you want to input text, use the
-//Unicode character callback instead.
+// The key functions deal with physical keys, with key tokens named after their
+// use on the standard US keyboard layout. If you want to input text, use the
+// Unicode character callback instead.
 func (w *Window) GetKey(key Key) Action {
 	return Action(C.glfwGetKey(w.data, C.int(key)))
 }
 
-//GetMouseButton returns the last state reported for the specified mouse button.
+// GetMouseButton returns the last state reported for the specified mouse button.
 //
-//If the StickyMouseButtons input mode is enabled, this function returns Press
-//the first time you call this function after a mouse button has been pressed,
-//even if the mouse button has already been released.
+// If the StickyMouseButtons input mode is enabled, this function returns Press
+// the first time you call this function after a mouse button has been pressed,
+// even if the mouse button has already been released.
 func (w *Window) GetMouseButton(button MouseButton) Action {
 	return Action(C.glfwGetMouseButton(w.data, C.int(button)))
 }
 
-//GetCursorPosition returns the last reported position of the cursor.
+// GetCursorPosition returns the last reported position of the cursor.
 //
-//If the cursor is disabled (with CursorDisabled) then the cursor position is
-//unbounded and limited only by the minimum and maximum values of a double.
+// If the cursor is disabled (with CursorDisabled) then the cursor position is
+// unbounded and limited only by the minimum and maximum values of a double.
 //
-//The coordinate can be converted to their integer equivalents with the floor
-//function. Casting directly to an integer type works for positive coordinates,
-//but fails for negative ones.
+// The coordinate can be converted to their integer equivalents with the floor
+// function. Casting directly to an integer type works for positive coordinates,
+// but fails for negative ones.
 func (w *Window) GetCursorPosition() (x, y float64) {
 	var xpos, ypos C.double
 	C.glfwGetCursorPos(w.data, &xpos, &ypos)
 	return float64(xpos), float64(ypos)
 }
 
-//SetCursorPosition sets the position of the cursor. The specified window must
-//be focused. If the window does not have focus when this function is called,
-//it fails silently.
+// SetCursorPosition sets the position of the cursor. The specified window must
+// be focused. If the window does not have focus when this function is called,
+// it fails silently.
 //
-//If the cursor is disabled (with CursorDisabled) then the cursor position is
-//unbounded and limited only by the minimum and maximum values of a double.
+// If the cursor is disabled (with CursorDisabled) then the cursor position is
+// unbounded and limited only by the minimum and maximum values of a double.
 func (w *Window) SetCursorPosition(xpos, ypos float64) {
 	C.glfwSetCursorPos(w.data, C.double(xpos), C.double(ypos))
 }
 
-//SetKeyCallback sets the key callback which is called when a key is pressed,
-//repeated or released.
+// SetKeyCallback sets the key callback which is called when a key is pressed,
+// repeated or released.
 //
-//The key functions deal with physical keys, with layout independent key tokens
-//named after their values in the standard US keyboard layout. If you want to
-//input text, use the SetCharCallback instead.
+// The key functions deal with physical keys, with layout independent key tokens
+// named after their values in the standard US keyboard layout. If you want to
+// input text, use the SetCharCallback instead.
 //
-//When a window loses focus, it will generate synthetic key release events for
-//all pressed keys. You can tell these events from user-generated events by the
-//fact that the synthetic ones are generated after the window has lost focus,
-//i.e. Focused will be false and the focus callback will have already been
-//called.
+// When a window loses focus, it will generate synthetic key release events for
+// all pressed keys. You can tell these events from user-generated events by the
+// fact that the synthetic ones are generated after the window has lost focus,
+// i.e. Focused will be false and the focus callback will have already been
+// called.
 func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, action Action, mods ModifierKey)) {
 	if cbfun == nil {
 		C.glfwSetKeyCallback(w.data, nil)
@@ -363,20 +363,20 @@ func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, act
 	}
 }
 
-//SetCharacterCallback sets the character callback which is called when a
-//Unicode character is input.
+// SetCharacterCallback sets the character callback which is called when a
+// Unicode character is input.
 //
-//The character callback is intended for Unicode text input. As it deals with
-//characters, it is keyboard layout dependent, whereas the
-//key callback is not. Characters do not map 1:1
-//to physical keys, as a key may produce zero, one or more characters. If you
-//want to know whether a specific physical key was pressed or released, see
-//the key callback instead.
+// The character callback is intended for Unicode text input. As it deals with
+// characters, it is keyboard layout dependent, whereas the
+// key callback is not. Characters do not map 1:1
+// to physical keys, as a key may produce zero, one or more characters. If you
+// want to know whether a specific physical key was pressed or released, see
+// the key callback instead.
 //
-//The character callback behaves as system text input normally does and will
-//not be called if modifier keys are held down that would prevent normal text
-//input on that platform, for example a Super (Command) key on OS X or Alt key
-//on Windows. There is a character with modifiers callback that receives these events.
+// The character callback behaves as system text input normally does and will
+// not be called if modifier keys are held down that would prevent normal text
+// input on that platform, for example a Super (Command) key on OS X or Alt key
+// on Windows. There is a character with modifiers callback that receives these events.
 func (w *Window) SetCharacterCallback(cbfun func(w *Window, char rune)) {
 	if cbfun == nil {
 		C.glfwSetCharCallback(w.data, nil)
@@ -386,16 +386,16 @@ func (w *Window) SetCharacterCallback(cbfun func(w *Window, char rune)) {
 	}
 }
 
-//SetCharacterModsCallback sets the character with modifiers callback which is called when a
-//Unicode character is input regardless of what modifier keys are used.
+// SetCharacterModsCallback sets the character with modifiers callback which is called when a
+// Unicode character is input regardless of what modifier keys are used.
 //
-//The character with modifiers callback is intended for implementing custom
-//Unicode character input. For regular Unicode text input, see the
-//character callback. Like the character callback, the character with modifiers callback
-//deals with characters and is keyboard layout dependent. Characters do not
-//map 1:1 to physical keys, as a key may produce zero, one or more characters.
-//If you want to know whether a specific physical key was pressed or released,
-//see the key callback instead.
+// The character with modifiers callback is intended for implementing custom
+// Unicode character input. For regular Unicode text input, see the
+// character callback. Like the character callback, the character with modifiers callback
+// deals with characters and is keyboard layout dependent. Characters do not
+// map 1:1 to physical keys, as a key may produce zero, one or more characters.
+// If you want to know whether a specific physical key was pressed or released,
+// see the key callback instead.
 func (w *Window) SetCharacterModsCallback(cbfun func(w *Window, char rune, mods ModifierKey)) {
 	if cbfun == nil {
 		C.glfwSetCharModsCallback(w.data, nil)
@@ -405,14 +405,14 @@ func (w *Window) SetCharacterModsCallback(cbfun func(w *Window, char rune, mods 
 	}
 }
 
-//SetMouseButtonCallback sets the mouse button callback which is called when a
-//mouse button is pressed or released.
+// SetMouseButtonCallback sets the mouse button callback which is called when a
+// mouse button is pressed or released.
 //
-//When a window loses focus, it will generate synthetic mouse button release
-//events for all pressed mouse buttons. You can tell these events from
-//user-generated events by the fact that the synthetic ones are generated after
-//the window has lost focus, i.e. Focused will be false and the focus
-//callback will have already been called.
+// When a window loses focus, it will generate synthetic mouse button release
+// events for all pressed mouse buttons. You can tell these events from
+// user-generated events by the fact that the synthetic ones are generated after
+// the window has lost focus, i.e. Focused will be false and the focus
+// callback will have already been called.
 func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton, action Action, mod ModifierKey)) {
 	if cbfun == nil {
 		C.glfwSetMouseButtonCallback(w.data, nil)
@@ -422,9 +422,9 @@ func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton
 	}
 }
 
-//SetCursorPositionCallback sets the cursor position callback which is called
-//when the cursor is moved. The callback is provided with the position relative
-//to the upper-left corner of the client area of the window.
+// SetCursorPositionCallback sets the cursor position callback which is called
+// when the cursor is moved. The callback is provided with the position relative
+// to the upper-left corner of the client area of the window.
 func (w *Window) SetCursorPositionCallback(cbfun func(w *Window, xpos float64, ypos float64)) {
 	if cbfun == nil {
 		C.glfwSetCursorPosCallback(w.data, nil)
@@ -434,8 +434,8 @@ func (w *Window) SetCursorPositionCallback(cbfun func(w *Window, xpos float64, y
 	}
 }
 
-//SetCursorEnterCallback the cursor boundary crossing callback which is called
-//when the cursor enters or leaves the client area of the window.
+// SetCursorEnterCallback the cursor boundary crossing callback which is called
+// when the cursor enters or leaves the client area of the window.
 func (w *Window) SetCursorEnterCallback(cbfun func(w *Window, entered bool)) {
 	if cbfun == nil {
 		C.glfwSetCursorEnterCallback(w.data, nil)
@@ -445,8 +445,8 @@ func (w *Window) SetCursorEnterCallback(cbfun func(w *Window, entered bool)) {
 	}
 }
 
-//SetScrollCallback sets the scroll callback which is called when a scrolling
-//device is used, such as a mouse wheel or scrolling area of a touchpad.
+// SetScrollCallback sets the scroll callback which is called when a scrolling
+// device is used, such as a mouse wheel or scrolling area of a touchpad.
 func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff float64)) {
 	if cbfun == nil {
 		C.glfwSetScrollCallback(w.data, nil)
@@ -456,8 +456,8 @@ func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff floa
 	}
 }
 
-//SetDropCallback sets the drop callback which is called when an object
-//is dropped over the window.
+// SetDropCallback sets the drop callback which is called when an object
+// is dropped over the window.
 func (w *Window) SetDropCallback(cbfun func(w *Window, names []string)) {
 	if cbfun == nil {
 		C.glfwSetDropCallback(w.data, nil)
@@ -467,12 +467,12 @@ func (w *Window) SetDropCallback(cbfun func(w *Window, names []string)) {
 	}
 }
 
-//GetJoystickPresent returns whether the specified joystick is present.
+// GetJoystickPresent returns whether the specified joystick is present.
 func JoystickPresent(joy Joystick) bool {
 	return glfwbool(C.glfwJoystickPresent(C.int(joy)))
 }
 
-//GetJoystickAxes returns a slice of axis values.
+// GetJoystickAxes returns a slice of axis values.
 func GetJoystickAxes(joy Joystick) []float32 {
 	var length int
 
@@ -489,7 +489,7 @@ func GetJoystickAxes(joy Joystick) []float32 {
 	return a
 }
 
-//GetJoystickButtons returns a slice of button values.
+// GetJoystickButtons returns a slice of button values.
 func GetJoystickButtons(joy Joystick) []byte {
 	var length int
 
@@ -506,7 +506,7 @@ func GetJoystickButtons(joy Joystick) []byte {
 	return b
 }
 
-//GetJoystickName returns the name, encoded as UTF-8, of the specified joystick.
+// GetJoystickName returns the name, encoded as UTF-8, of the specified joystick.
 func GetJoystickName(joy Joystick) string {
 	jn := C.glfwGetJoystickName(C.int(joy))
 	return C.GoString(jn)

--- a/monitor.go
+++ b/monitor.go
@@ -16,30 +16,30 @@ type Monitor struct {
 	data *C.GLFWmonitor
 }
 
-//MonitorEvent corresponds to a monitor configuration event.
+// MonitorEvent corresponds to a monitor configuration event.
 type MonitorEvent int
 
-//GammaRamp describes the gamma ramp for a monitor.
+// GammaRamp describes the gamma ramp for a monitor.
 type GammaRamp struct {
-	Red   []uint16 //A slice of value describing the response of the red channel.
-	Green []uint16 //A slice of value describing the response of the green channel.
-	Blue  []uint16 //A slice of value describing the response of the blue channel.
+	Red   []uint16 // A slice of value describing the response of the red channel.
+	Green []uint16 // A slice of value describing the response of the green channel.
+	Blue  []uint16 // A slice of value describing the response of the blue channel.
 }
 
-//Monitor events.
+// Monitor events.
 const (
 	Connected    MonitorEvent = C.GLFW_CONNECTED
 	Disconnected MonitorEvent = C.GLFW_DISCONNECTED
 )
 
-//VideoMode describes a single video mode.
+// VideoMode describes a single video mode.
 type VideoMode struct {
-	Width       int //The width, in pixels, of the video mode.
-	Height      int //The height, in pixels, of the video mode.
-	RedBits     int //The bit depth of the red channel of the video mode.
-	GreenBits   int //The bit depth of the green channel of the video mode.
-	BlueBits    int //The bit depth of the blue channel of the video mode.
-	RefreshRate int //The refresh rate, in Hz, of the video mode.
+	Width       int // The width, in pixels, of the video mode.
+	Height      int // The height, in pixels, of the video mode.
+	RedBits     int // The bit depth of the red channel of the video mode.
+	GreenBits   int // The bit depth of the green channel of the video mode.
+	BlueBits    int // The bit depth of the blue channel of the video mode.
+	RefreshRate int // The refresh rate, in Hz, of the video mode.
 }
 
 var fMonitorHolder func(monitor *Monitor, event MonitorEvent)
@@ -49,7 +49,7 @@ func goMonitorCB(monitor unsafe.Pointer, event C.int) {
 	fMonitorHolder(&Monitor{(*C.GLFWmonitor)(monitor)}, MonitorEvent(event))
 }
 
-//GetMonitors returns a slice of handles for all currently connected monitors.
+// GetMonitors returns a slice of handles for all currently connected monitors.
 func GetMonitors() ([]*Monitor, error) {
 	var length int
 
@@ -67,8 +67,8 @@ func GetMonitors() ([]*Monitor, error) {
 	return m, nil
 }
 
-//GetPrimaryMonitor returns the primary monitor. This is usually the monitor
-//where elements like the Windows task bar or the OS X menu bar is located.
+// GetPrimaryMonitor returns the primary monitor. This is usually the monitor
+// where elements like the Windows task bar or the OS X menu bar is located.
 func GetPrimaryMonitor() (*Monitor, error) {
 	m := C.glfwGetPrimaryMonitor()
 	if m == nil {
@@ -77,27 +77,27 @@ func GetPrimaryMonitor() (*Monitor, error) {
 	return &Monitor{m}, nil
 }
 
-//GetPosition returns the position, in screen coordinates, of the upper-left
-//corner of the monitor.
+// GetPosition returns the position, in screen coordinates, of the upper-left
+// corner of the monitor.
 func (m *Monitor) GetPosition() (x, y int) {
 	var xpos, ypos C.int
 	C.glfwGetMonitorPos(m.data, &xpos, &ypos)
 	return int(xpos), int(ypos)
 }
 
-//GetPhysicalSize returns the size, in millimetres, of the display area of the
-//monitor.
+// GetPhysicalSize returns the size, in millimetres, of the display area of the
+// monitor.
 //
-//Note: Some operating systems do not provide accurate information, either
-//because the monitor's EDID data is incorrect, or because the driver does not
-//report it accurately.
+// Note: Some operating systems do not provide accurate information, either
+// because the monitor's EDID data is incorrect, or because the driver does not
+// report it accurately.
 func (m *Monitor) GetPhysicalSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetMonitorPhysicalSize(m.data, &wi, &h)
 	return int(wi), int(h)
 }
 
-//GetName returns a human-readable name of the monitor, encoded as UTF-8.
+// GetName returns a human-readable name of the monitor, encoded as UTF-8.
 func (m *Monitor) GetName() (string, error) {
 	mn := C.glfwGetMonitorName(m.data)
 	if mn == nil {
@@ -106,9 +106,9 @@ func (m *Monitor) GetName() (string, error) {
 	return C.GoString(mn), nil
 }
 
-//SetMonitorCallback sets the monitor configuration callback, or removes the
-//currently set callback. This is called when a monitor is connected to or
-//disconnected from the system.
+// SetMonitorCallback sets the monitor configuration callback, or removes the
+// currently set callback. This is called when a monitor is connected to or
+// disconnected from the system.
 func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
 	if cbfun == nil {
 		C.glfwSetMonitorCallback(nil)
@@ -118,10 +118,10 @@ func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
 	}
 }
 
-//GetVideoModes returns an array of all video modes supported by the monitor.
-//The returned array is sorted in ascending order, first by color bit depth
-//(the sum of all channel depths) and then by resolution area (the product of
-//width and height).
+// GetVideoModes returns an array of all video modes supported by the monitor.
+// The returned array is sorted in ascending order, first by color bit depth
+// (the sum of all channel depths) and then by resolution area (the product of
+// width and height).
 func (m *Monitor) GetVideoModes() ([]*VideoMode, error) {
 	var length int
 
@@ -140,9 +140,9 @@ func (m *Monitor) GetVideoModes() ([]*VideoMode, error) {
 	return v, nil
 }
 
-//GetVideoMode returns the current video mode of the monitor. If you
-//are using a full screen window, the return value will therefore depend on
-//whether it is focused.
+// GetVideoMode returns the current video mode of the monitor. If you
+// are using a full screen window, the return value will therefore depend on
+// whether it is focused.
 func (m *Monitor) GetVideoMode() (*VideoMode, error) {
 	t := C.glfwGetVideoMode(m.data)
 	if t == nil {
@@ -151,13 +151,13 @@ func (m *Monitor) GetVideoMode() (*VideoMode, error) {
 	return &VideoMode{int(t.width), int(t.height), int(t.redBits), int(t.greenBits), int(t.blueBits), int(t.refreshRate)}, nil
 }
 
-//SetGamma generates a 256-element gamma ramp from the specified exponent and then calls
-//SetGamma with it.
+// SetGamma generates a 256-element gamma ramp from the specified exponent and then calls
+// SetGamma with it.
 func (m *Monitor) SetGamma(gamma float32) {
 	C.glfwSetGamma(m.data, C.float(gamma))
 }
 
-//GetGammaRamp retrieves the current gamma ramp of the monitor.
+// GetGammaRamp retrieves the current gamma ramp of the monitor.
 func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 	var ramp GammaRamp
 
@@ -180,7 +180,7 @@ func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 	return &ramp, nil
 }
 
-//SetGammaRamp sets the current gamma ramp for the monitor.
+// SetGammaRamp sets the current gamma ramp for the monitor.
 func (m *Monitor) SetGammaRamp(ramp *GammaRamp) {
 	var rampC C.GLFWgammaramp
 

--- a/time.go
+++ b/time.go
@@ -3,12 +3,12 @@ package glfw3
 //#include <GLFW/glfw3.h>
 import "C"
 
-//GetTime returns the value of the GLFW timer. Unless the timer has been set
-//using SetTime, the timer measures time elapsed since GLFW was initialized.
+// GetTime returns the value of the GLFW timer. Unless the timer has been set
+// using SetTime, the timer measures time elapsed since GLFW was initialized.
 //
-//The resolution of the timer is system dependent, but is usually on the order
-//of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
-//source on each supported platform.
+// The resolution of the timer is system dependent, but is usually on the order
+// of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
+// source on each supported platform.
 func GetTime() (float64, error) {
 	r := float64(C.glfwGetTime())
 	if r == 0 {
@@ -17,12 +17,12 @@ func GetTime() (float64, error) {
 	return r, nil
 }
 
-//SetTime sets the value of the GLFW timer. It then continues to count up from
-//that value.
+// SetTime sets the value of the GLFW timer. It then continues to count up from
+// that value.
 //
-//The resolution of the timer is system dependent, but is usually on the order
-//of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
-//source on each supported platform.
+// The resolution of the timer is system dependent, but is usually on the order
+// of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
+// source on each supported platform.
 func SetTime(time float64) {
 	C.glfwSetTime(C.double(time))
 }

--- a/window.go
+++ b/window.go
@@ -42,73 +42,73 @@ func (w *windowList) get(wnd *C.GLFWwindow) *Window {
 	return w.m[wnd]
 }
 
-//Hint corresponds to hints that can be set before creating a window.
+// Hint corresponds to hints that can be set before creating a window.
 //
-//Hint also corresponds to the attributes of the window that can be get after
-//its creation.
+// Hint also corresponds to the attributes of the window that can be get after
+// its creation.
 type Hint int
 
-//Window related hints.
+// Window related hints.
 const (
-	Focused   Hint = C.GLFW_FOCUSED   //Specifies whether the window will be focused.
-	Iconified Hint = C.GLFW_ICONIFIED //Specifies whether the window will be minimized.
-	Visible   Hint = C.GLFW_VISIBLE   //Specifies whether the window will be initially visible.
-	Resizable Hint = C.GLFW_RESIZABLE //Specifies whether the window will be resizable by the user.
-	Decorated Hint = C.GLFW_DECORATED //Specifies whether the window will have window decorations such as a border, a close widget, etc.
+	Focused   Hint = C.GLFW_FOCUSED   // Specifies whether the window will be focused.
+	Iconified Hint = C.GLFW_ICONIFIED // Specifies whether the window will be minimized.
+	Visible   Hint = C.GLFW_VISIBLE   // Specifies whether the window will be initially visible.
+	Resizable Hint = C.GLFW_RESIZABLE // Specifies whether the window will be resizable by the user.
+	Decorated Hint = C.GLFW_DECORATED // Specifies whether the window will have window decorations such as a border, a close widget, etc.
 )
 
-//Context related hints.
+// Context related hints.
 const (
-	ClientApi               Hint = C.GLFW_CLIENT_API            //Specifies which client API to create the context for. Hard constraint.
-	ContextVersionMajor     Hint = C.GLFW_CONTEXT_VERSION_MAJOR //Specifies the client API version that the created context must be compatible with.
-	ContextVersionMinor     Hint = C.GLFW_CONTEXT_VERSION_MINOR //Specifies the client API version that the created context must be compatible with.
-	ContextRobustness       Hint = C.GLFW_CONTEXT_ROBUSTNESS    //Specifies the robustness strategy to be used by the context.
-	OpenglForwardCompatible Hint = C.GLFW_OPENGL_FORWARD_COMPAT //Specifies whether the OpenGL context should be forward-compatible. Hard constraint.
+	ClientApi               Hint = C.GLFW_CLIENT_API            // Specifies which client API to create the context for. Hard constraint.
+	ContextVersionMajor     Hint = C.GLFW_CONTEXT_VERSION_MAJOR // Specifies the client API version that the created context must be compatible with.
+	ContextVersionMinor     Hint = C.GLFW_CONTEXT_VERSION_MINOR // Specifies the client API version that the created context must be compatible with.
+	ContextRobustness       Hint = C.GLFW_CONTEXT_ROBUSTNESS    // Specifies the robustness strategy to be used by the context.
+	OpenglForwardCompatible Hint = C.GLFW_OPENGL_FORWARD_COMPAT // Specifies whether the OpenGL context should be forward-compatible. Hard constraint.
 	OpenglDebugContext      Hint = C.GLFW_OPENGL_DEBUG_CONTEXT
-	OpenglProfile           Hint = C.GLFW_OPENGL_PROFILE //Specifies which OpenGL profile to create the context for. Hard constraint.
+	OpenglProfile           Hint = C.GLFW_OPENGL_PROFILE // Specifies which OpenGL profile to create the context for. Hard constraint.
 )
 
-//Framebuffer related hints.
+// Framebuffer related hints.
 const (
 	ContextRevision Hint = C.GLFW_CONTEXT_REVISION
-	RedBits         Hint = C.GLFW_RED_BITS         //Specifies the desired bit depth of the default framebuffer.
-	GreenBits       Hint = C.GLFW_GREEN_BITS       //Specifies the desired bit depth of the default framebuffer.
-	BlueBits        Hint = C.GLFW_BLUE_BITS        //Specifies the desired bit depth of the default framebuffer.
-	AlphaBits       Hint = C.GLFW_ALPHA_BITS       //Specifies the desired bit depth of the default framebuffer.
-	DepthBits       Hint = C.GLFW_DEPTH_BITS       //Specifies the desired bit depth of the default framebuffer.
-	StencilBits     Hint = C.GLFW_STENCIL_BITS     //Specifies the desired bit depth of the default framebuffer.
-	AccumRedBits    Hint = C.GLFW_ACCUM_RED_BITS   //Specifies the desired bit depth of the accumulation buffer.
-	AccumGreenBits  Hint = C.GLFW_ACCUM_GREEN_BITS //Specifies the desired bit depth of the accumulation buffer.
-	AccumBlueBits   Hint = C.GLFW_ACCUM_BLUE_BITS  //Specifies the desired bit depth of the accumulation buffer.
-	AccumAlphaBits  Hint = C.GLFW_ACCUM_ALPHA_BITS //Specifies the desired bit depth of the accumulation buffer.
-	AuxBuffers      Hint = C.GLFW_AUX_BUFFERS      //Specifies the desired number of auxiliary buffers.
-	Stereo          Hint = C.GLFW_STEREO           //Specifies whether to use stereoscopic rendering. Hard constraint.
-	Samples         Hint = C.GLFW_SAMPLES          //Specifies the desired number of samples to use for multisampling. Zero disables multisampling.
-	SrgbCapable     Hint = C.GLFW_SRGB_CAPABLE     //Specifies whether the framebuffer should be sRGB capable.
-	RefreshRate     Hint = C.GLFW_REFRESH_RATE     //specifies the desired refresh rate for full screen windows. If set to zero, the highest available refresh rate will be used. This hint is ignored for windowed mode windows.
+	RedBits         Hint = C.GLFW_RED_BITS         // Specifies the desired bit depth of the default framebuffer.
+	GreenBits       Hint = C.GLFW_GREEN_BITS       // Specifies the desired bit depth of the default framebuffer.
+	BlueBits        Hint = C.GLFW_BLUE_BITS        // Specifies the desired bit depth of the default framebuffer.
+	AlphaBits       Hint = C.GLFW_ALPHA_BITS       // Specifies the desired bit depth of the default framebuffer.
+	DepthBits       Hint = C.GLFW_DEPTH_BITS       // Specifies the desired bit depth of the default framebuffer.
+	StencilBits     Hint = C.GLFW_STENCIL_BITS     // Specifies the desired bit depth of the default framebuffer.
+	AccumRedBits    Hint = C.GLFW_ACCUM_RED_BITS   // Specifies the desired bit depth of the accumulation buffer.
+	AccumGreenBits  Hint = C.GLFW_ACCUM_GREEN_BITS // Specifies the desired bit depth of the accumulation buffer.
+	AccumBlueBits   Hint = C.GLFW_ACCUM_BLUE_BITS  // Specifies the desired bit depth of the accumulation buffer.
+	AccumAlphaBits  Hint = C.GLFW_ACCUM_ALPHA_BITS // Specifies the desired bit depth of the accumulation buffer.
+	AuxBuffers      Hint = C.GLFW_AUX_BUFFERS      // Specifies the desired number of auxiliary buffers.
+	Stereo          Hint = C.GLFW_STEREO           // Specifies whether to use stereoscopic rendering. Hard constraint.
+	Samples         Hint = C.GLFW_SAMPLES          // Specifies the desired number of samples to use for multisampling. Zero disables multisampling.
+	SrgbCapable     Hint = C.GLFW_SRGB_CAPABLE     // Specifies whether the framebuffer should be sRGB capable.
+	RefreshRate     Hint = C.GLFW_REFRESH_RATE     // specifies the desired refresh rate for full screen windows. If set to zero, the highest available refresh rate will be used. This hint is ignored for windowed mode windows.
 )
 
-//Values for the ClientApi hint.
+// Values for the ClientApi hint.
 const (
 	OpenglApi   int = C.GLFW_OPENGL_API
 	OpenglEsApi int = C.GLFW_OPENGL_ES_API
 )
 
-//Values for the ContextRobustness hint.
+// Values for the ContextRobustness hint.
 const (
 	NoRobustness        int = C.GLFW_NO_ROBUSTNESS
 	NoResetNotification int = C.GLFW_NO_RESET_NOTIFICATION
 	LoseContextOnReset  int = C.GLFW_LOSE_CONTEXT_ON_RESET
 )
 
-//Values for the OpenglProfile hint.
+// Values for the OpenglProfile hint.
 const (
 	OpenglAnyProfile    int = C.GLFW_OPENGL_ANY_PROFILE
 	OpenglCoreProfile   int = C.GLFW_OPENGL_CORE_PROFILE
 	OpenglCompatProfile int = C.GLFW_OPENGL_COMPAT_PROFILE
 )
 
-//TRUE and FALSE values to use with hints.
+// TRUE and FALSE values to use with hints.
 const (
 	True  int = C.GL_TRUE
 	False int = C.GL_FALSE
@@ -181,56 +181,53 @@ func goWindowIconifyCB(window unsafe.Pointer, iconified C.int) {
 	w.fIconifyHolder(w, isIconified)
 }
 
-//DefaultHints resets all window hints to their default values.
+// DefaultHints resets all window hints to their default values.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func DefaultWindowHints() {
 	C.glfwDefaultWindowHints()
 }
 
-//Hint function sets hints for the next call to CreateWindow. The hints,
-//once set, retain their values until changed by a call to Hint or
-//DefaultHints, or until the library is terminated with Terminate.
+// Hint function sets hints for the next call to CreateWindow. The hints,
+// once set, retain their values until changed by a call to Hint or
+// DefaultHints, or until the library is terminated with Terminate.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func WindowHint(target Hint, hint int) {
 	C.glfwWindowHint(C.int(target), C.int(hint))
 }
 
-//CreateWindow creates a window and its associated context. Most of the options
-//controlling how the window and its context should be created are specified
-//through Hint.
+// CreateWindow creates a window and its associated context. Most of the options
+// controlling how the window and its context should be created are specified
+// through Hint.
 //
-//Successful creation does not change which context is current. Before you can
-//use the newly created context, you need to make it current using
-//MakeContextCurrent.
+// Successful creation does not change which context is current. Before you can
+// use the newly created context, you need to make it current using
+// MakeContextCurrent.
 //
-//Note that the created window and context may differ from what you requested,
-//as not all parameters and hints are hard constraints. This includes the size
-//of the window, especially for full screen windows. To retrieve the actual
-//attributes of the created window and context, use queries like
-//GetWindowAttrib and GetWindowSize.
+// Note that the created window and context may differ from what you requested,
+// as not all parameters and hints are hard constraints. This includes the size
+// of the window, especially for full screen windows. To retrieve the actual
+// attributes of the created window and context, use queries like
+// GetWindowAttrib and GetWindowSize.
 //
-//To create the window at a specific position, make it initially invisible using
-//the Visible window hint, set its position and then show it.
+// To create the window at a specific position, make it initially invisible using
+// the Visible window hint, set its position and then show it.
 //
-//If a fullscreen window is active, the screensaver is prohibited from starting.
+// If a fullscreen window is active, the screensaver is prohibited from starting.
 //
-//Windows: If the executable has an icon resource named GLFW_ICON, it will be
-//set as the icon for the window. If no such icon is present, the IDI_WINLOGO
-//icon will be used instead.
+// Windows: If the executable has an icon resource named GLFW_ICON, it will be
+// set as the icon for the window. If no such icon is present, the IDI_WINLOGO
+// icon will be used instead.
 //
-//Mac OS X: The GLFW window has no icon, as it is not a document window, but the
-//dock icon will be the same as the application bundle's icon. Also, the first
-//time a window is opened the menu bar is populated with common commands like
-//Hide, Quit and About. The (minimal) about dialog uses information from the
-//application's bundle. For more information on bundles, see the Bundle
-//Programming Guide provided by Apple.
+// Mac OS X: The GLFW window has no icon, as it is not a document window, but the
+// dock icon will be the same as the application bundle's icon. Also, the first
+// time a window is opened the menu bar is populated with common commands like
+// Hide, Quit and About. The (minimal) about dialog uses information from the
+// application's bundle. For more information on bundles, see the Bundle
+// Programming Guide provided by Apple.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func CreateWindow(width, height int, title string, monitor *Monitor, share *Window) (*Window, error) {
 	var (
 		m *C.GLFWmonitor
@@ -258,24 +255,23 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 	return wnd, nil
 }
 
-//Destroy destroys the specified window and its context. On calling this
-//function, no further callbacks will be called for that window.
+// Destroy destroys the specified window and its context. On calling this
+// function, no further callbacks will be called for that window.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) Destroy() {
 	windows.remove(w.data)
 	C.glfwDestroyWindow(w.data)
 }
 
-//ShouldClose returns the value of the close flag of the specified window.
+// ShouldClose returns the value of the close flag of the specified window.
 func (w *Window) ShouldClose() bool {
 	return glfwbool(C.glfwWindowShouldClose(w.data))
 }
 
-//SetShouldClose sets the value of the close flag of the window. This can be
-//used to override the user's attempt to close the window, or to signal that it
-//should be closed.
+// SetShouldClose sets the value of the close flag of the window. This can be
+// used to override the user's attempt to close the window, or to signal that it
+// should be closed.
 func (w *Window) SetShouldClose(value bool) {
 	if !value {
 		C.glfwSetWindowShouldClose(w.data, C.GL_FALSE)
@@ -284,116 +280,109 @@ func (w *Window) SetShouldClose(value bool) {
 	}
 }
 
-//SetTitle sets the window title, encoded as UTF-8, of the window.
+// SetTitle sets the window title, encoded as UTF-8, of the window.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) SetTitle(title string) {
 	t := C.CString(title)
 	defer C.free(unsafe.Pointer(t))
 	C.glfwSetWindowTitle(w.data, t)
 }
 
-//GetPosition returns the position, in screen coordinates, of the upper-left
-//corner of the client area of the window.
+// GetPosition returns the position, in screen coordinates, of the upper-left
+// corner of the client area of the window.
 func (w *Window) GetPosition() (x, y int) {
 	var xpos, ypos C.int
 	C.glfwGetWindowPos(w.data, &xpos, &ypos)
 	return int(xpos), int(ypos)
 }
 
-//SetPosition sets the position, in screen coordinates, of the upper-left corner
-//of the client area of the window.
+// SetPosition sets the position, in screen coordinates, of the upper-left corner
+// of the client area of the window.
 //
-//If it is a full screen window, this function does nothing.
+// If it is a full screen window, this function does nothing.
 //
-//If you wish to set an initial window position you should create a hidden
-//window (using Hint and Visible), set its position and then show it.
+// If you wish to set an initial window position you should create a hidden
+// window (using Hint and Visible), set its position and then show it.
 //
-//It is very rarely a good idea to move an already visible window, as it will
-//confuse and annoy the user.
+// It is very rarely a good idea to move an already visible window, as it will
+// confuse and annoy the user.
 //
-//The window manager may put limits on what positions are allowed.
+// The window manager may put limits on what positions are allowed.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) SetPosition(xpos, ypos int) {
 	C.glfwSetWindowPos(w.data, C.int(xpos), C.int(ypos))
 }
 
-//GetSize returns the size, in screen coordinates, of the client area of the
-//specified window.
+// GetSize returns the size, in screen coordinates, of the client area of the
+// specified window.
 func (w *Window) GetSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetWindowSize(w.data, &wi, &h)
 	return int(wi), int(h)
 }
 
-//SetSize sets the size, in screen coordinates, of the client area of the
-//window.
+// SetSize sets the size, in screen coordinates, of the client area of the
+// window.
 //
-//For full screen windows, this function selects and switches to the resolution
-//closest to the specified size, without affecting the window's context. As the
-//context is unaffected, the bit depths of the framebuffer remain unchanged.
+// For full screen windows, this function selects and switches to the resolution
+// closest to the specified size, without affecting the window's context. As the
+// context is unaffected, the bit depths of the framebuffer remain unchanged.
 //
-//The window manager may put limits on what window sizes are allowed.
+// The window manager may put limits on what window sizes are allowed.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) SetSize(width, height int) {
 	C.glfwSetWindowSize(w.data, C.int(width), C.int(height))
 }
 
-//GetFramebufferSize retrieves the size, in pixels, of the framebuffer of the
-//specified window.
+// GetFramebufferSize retrieves the size, in pixels, of the framebuffer of the
+// specified window.
 func (w *Window) GetFramebufferSize() (width, height int) {
 	var wi, h C.int
 	C.glfwGetFramebufferSize(w.data, &wi, &h)
 	return int(wi), int(h)
 }
 
-//Iconfiy iconifies/minimizes the window, if it was previously restored. If it
-//is a full screen window, the original monitor resolution is restored until the
-//window is restored. If the window is already iconified, this function does
-//nothing.
+// Iconfiy iconifies/minimizes the window, if it was previously restored. If it
+// is a full screen window, the original monitor resolution is restored until the
+// window is restored. If the window is already iconified, this function does
+// nothing.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) Iconify() {
 	C.glfwIconifyWindow(w.data)
 }
 
-//Restore restores the window, if it was previously iconified/minimized. If it
-//is a full screen window, the resolution chosen for the window is restored on
-//the selected monitor. If the window is already restored, this function does
-//nothing.
+// Restore restores the window, if it was previously iconified/minimized. If it
+// is a full screen window, the resolution chosen for the window is restored on
+// the selected monitor. If the window is already restored, this function does
+// nothing.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) Restore() {
 	C.glfwRestoreWindow(w.data)
 }
 
-//Show makes the window visible, if it was previously hidden. If the window is
-//already visible or is in full screen mode, this function does nothing.
+// Show makes the window visible, if it was previously hidden. If the window is
+// already visible or is in full screen mode, this function does nothing.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) Show() {
 	C.glfwShowWindow(w.data)
 }
 
-//Hide hides the window, if it was previously visible. If the window is already
-//hidden or is in full screen mode, this function does nothing.
+// Hide hides the window, if it was previously visible. If the window is already
+// hidden or is in full screen mode, this function does nothing.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func (w *Window) Hide() {
 	C.glfwHideWindow(w.data)
 }
 
-//GetMonitor returns the handle of the monitor that the window is in
-//fullscreen on.
+// GetMonitor returns the handle of the monitor that the window is in
+// fullscreen on.
 func (w *Window) GetMonitor() *Monitor {
 	m := C.glfwGetWindowMonitor(w.data)
 	if m == nil {
@@ -402,8 +391,8 @@ func (w *Window) GetMonitor() *Monitor {
 	return &Monitor{m}
 }
 
-//GetAttribute returns an attribute of the window. There are many attributes,
-//some related to the window and others to its context.
+// GetAttribute returns an attribute of the window. There are many attributes,
+// some related to the window and others to its context.
 func (w *Window) GetAttribute(attrib Hint) (int, error) {
 	r := int(C.glfwGetWindowAttrib(w.data, C.int(attrib)))
 	if r == 0 {
@@ -412,21 +401,21 @@ func (w *Window) GetAttribute(attrib Hint) (int, error) {
 	return r, nil
 }
 
-//SetUserPointer sets the user-defined pointer of the window. The current value
-//is retained until the window is destroyed. The initial value is nil.
+// SetUserPointer sets the user-defined pointer of the window. The current value
+// is retained until the window is destroyed. The initial value is nil.
 func (w *Window) SetUserPointer(pointer unsafe.Pointer) {
 	C.glfwSetWindowUserPointer(w.data, pointer)
 }
 
-//GetUserPointer returns the current value of the user-defined pointer of the
-//window. The initial value is nil.
+// GetUserPointer returns the current value of the user-defined pointer of the
+// window. The initial value is nil.
 func (w *Window) GetUserPointer() unsafe.Pointer {
 	return C.glfwGetWindowUserPointer(w.data)
 }
 
-//SetPositionCallback sets the position callback of the window, which is called
-//when the window is moved. The callback is provided with the screen position
-//of the upper-left corner of the client area of the window.
+// SetPositionCallback sets the position callback of the window, which is called
+// when the window is moved. The callback is provided with the screen position
+// of the upper-left corner of the client area of the window.
 func (w *Window) SetPositionCallback(cbfun func(w *Window, xpos int, ypos int)) {
 	if cbfun == nil {
 		C.glfwSetWindowPosCallback(w.data, nil)
@@ -436,9 +425,9 @@ func (w *Window) SetPositionCallback(cbfun func(w *Window, xpos int, ypos int)) 
 	}
 }
 
-//SetSizeCallback sets the size callback of the window, which is called when
-//the window is resized. The callback is provided with the size, in screen
-//coordinates, of the client area of the window.
+// SetSizeCallback sets the size callback of the window, which is called when
+// the window is resized. The callback is provided with the size, in screen
+// coordinates, of the client area of the window.
 func (w *Window) SetSizeCallback(cbfun func(w *Window, width int, height int)) {
 	if cbfun == nil {
 		C.glfwSetWindowSizeCallback(w.data, nil)
@@ -448,8 +437,8 @@ func (w *Window) SetSizeCallback(cbfun func(w *Window, width int, height int)) {
 	}
 }
 
-//SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
-//window, which is called when the framebuffer of the specified window is resized.
+// SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
+// window, which is called when the framebuffer of the specified window is resized.
 func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, height int)) {
 	if cbfun == nil {
 		C.glfwSetFramebufferSizeCallback(w.data, nil)
@@ -459,15 +448,15 @@ func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, hei
 	}
 }
 
-//SetCloseCallback sets the close callback of the window, which is called when
-//the user attempts to close the window, for example by clicking the close
-//widget in the title bar.
+// SetCloseCallback sets the close callback of the window, which is called when
+// the user attempts to close the window, for example by clicking the close
+// widget in the title bar.
 //
-//The close flag is set before this callback is called, but you can modify it at
-//any time with SetShouldClose.
+// The close flag is set before this callback is called, but you can modify it at
+// any time with SetShouldClose.
 //
-//Mac OS X: Selecting Quit from the application menu will trigger the close
-//callback for all windows.
+// Mac OS X: Selecting Quit from the application menu will trigger the close
+// callback for all windows.
 func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
 	if cbfun == nil {
 		C.glfwSetWindowCloseCallback(w.data, nil)
@@ -477,13 +466,13 @@ func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
 	}
 }
 
-//SetRefreshCallback sets the refresh callback of the window, which
-//is called when the client area of the window needs to be redrawn, for example
-//if the window has been exposed after having been covered by another window.
+// SetRefreshCallback sets the refresh callback of the window, which
+// is called when the client area of the window needs to be redrawn, for example
+// if the window has been exposed after having been covered by another window.
 //
-//On compositing window systems such as Aero, Compiz or Aqua, where the window
-//contents are saved off-screen, this callback may be called only very
-//infrequently or never at all.
+// On compositing window systems such as Aero, Compiz or Aqua, where the window
+// contents are saved off-screen, this callback may be called only very
+// infrequently or never at all.
 func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
 	if cbfun == nil {
 		C.glfwSetWindowRefreshCallback(w.data, nil)
@@ -493,12 +482,12 @@ func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
 	}
 }
 
-//SetFocusCallback sets the focus callback of the window, which is called when
-//the window gains or loses focus.
+// SetFocusCallback sets the focus callback of the window, which is called when
+// the window gains or loses focus.
 //
-//After the focus callback is called for a window that lost focus, synthetic key
-//and mouse button release events will be generated for all such that had been
-//pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
+// After the focus callback is called for a window that lost focus, synthetic key
+// and mouse button release events will be generated for all such that had been
+// pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
 func (w *Window) SetFocusCallback(cbfun func(w *Window, focused bool)) {
 	if cbfun == nil {
 		C.glfwSetWindowFocusCallback(w.data, nil)
@@ -508,8 +497,8 @@ func (w *Window) SetFocusCallback(cbfun func(w *Window, focused bool)) {
 	}
 }
 
-//SetIconifyCallback sets the iconification callback of the window, which is
-//called when the window is iconified or restored.
+// SetIconifyCallback sets the iconification callback of the window, which is
+// called when the window is iconified or restored.
 func (w *Window) SetIconifyCallback(cbfun func(w *Window, iconified bool)) {
 	if cbfun == nil {
 		C.glfwSetWindowIconifyCallback(w.data, nil)
@@ -519,46 +508,44 @@ func (w *Window) SetIconifyCallback(cbfun func(w *Window, iconified bool)) {
 	}
 }
 
-//PollEvents processes only those events that have already been received and
-//then returns immediately. Processing events will cause the window and input
-//callbacks associated with those events to be called.
+// PollEvents processes only those events that have already been received and
+// then returns immediately. Processing events will cause the window and input
+// callbacks associated with those events to be called.
 //
-//This function is not required for joystick input to work.
+// This function is not required for joystick input to work.
 //
-//This function may not be called from a callback.
+// This function may not be called from a callback.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func PollEvents() {
 	C.glfwPollEvents()
 }
 
-//WaitEvents puts the calling thread to sleep until at least one event has been
-//received. Once one or more events have been recevied, it behaves as if
-//PollEvents was called, i.e. the events are processed and the function then
-//returns immediately. Processing events will cause the window and input
-//callbacks associated with those events to be called.
+// WaitEvents puts the calling thread to sleep until at least one event has been
+// received. Once one or more events have been recevied, it behaves as if
+// PollEvents was called, i.e. the events are processed and the function then
+// returns immediately. Processing events will cause the window and input
+// callbacks associated with those events to be called.
 //
-//Since not all events are associated with callbacks, this function may return
-//without a callback having been called even if you are monitoring all
-//callbacks.
+// Since not all events are associated with callbacks, this function may return
+// without a callback having been called even if you are monitoring all
+// callbacks.
 //
-//This function may not be called from a callback.
+// This function may not be called from a callback.
 //
-//This function may only be called from the main thread. See
-//https://code.google.com/p/go-wiki/wiki/LockOSThread
+// This function may only be called from the main thread.
 func WaitEvents() {
 	C.glfwWaitEvents()
 }
 
-//PostEmptyEvent posts an empty event from the current thread to the main
-//thread event queue, causing WaitEvents to return.
+// PostEmptyEvent posts an empty event from the current thread to the main
+// thread event queue, causing WaitEvents to return.
 //
-//If no windows exist, this function returns immediately.  For
-//synchronization of threads in applications that do not create windows, use
-//your threading library of choice.
+// If no windows exist, this function returns immediately.  For
+// synchronization of threads in applications that do not create windows, use
+// your threading library of choice.
 //
-//This function may be called from secondary threads.
+// This function may be called from secondary threads.
 func PostEmptyEvent() {
 	C.glfwPostEmptyEvent()
 }


### PR DESCRIPTION
- Use more idiomatic style for comments, which includes a space after the `//`. See https://code.google.com/p/go-wiki/wiki/CodeReviewComments#Comment_Sentences.
- Remove references to LockOSThread Wiki example; simply mention `runtime.LockOSThread()` in README instead.
- Other than docs, there are no code or behavior changes.

Closes #70.
Closes #69.
