### PR TITLE
Return previous callbacks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,5 +4,6 @@
 
 Coşku Baş
 Dmitri Shuralyov
-Robin Eklind
 James Gray
+Peter Waller <p@pwaller.net> (github:pwaller)
+Robin Eklind

--- a/error.go
+++ b/error.go
@@ -20,7 +20,9 @@ const (
 	FormatUnavailable  ErrorCode = C.GLFW_FORMAT_UNAVAILABLE  //The clipboard did not contain data in the requested format.
 )
 
-var fErrorHolder func(code ErrorCode, desc string)
+type ErrorCallback func(code ErrorCode, desc string)
+
+var fErrorHolder ErrorCallback
 
 //export goErrorCB
 func goErrorCB(code C.int, desc *C.char) {
@@ -31,11 +33,13 @@ func goErrorCB(code C.int, desc *C.char) {
 //and a human-readable description each time a GLFW error occurs.
 //
 //This function may be called before Init.
-func SetErrorCallback(cbfun func(code ErrorCode, desc string)) {
+func SetErrorCallback(cbfun ErrorCallback) ErrorCallback {
+	old := fErrorHolder
+	fErrorHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetErrorCallback(nil)
 	} else {
-		fErrorHolder = cbfun
 		C.glfwSetErrorCallbackCB()
 	}
+	return old
 }

--- a/input.go
+++ b/input.go
@@ -324,6 +324,8 @@ func (w *Window) SetCursorPosition(xpos, ypos float64) {
 	C.glfwSetCursorPos(w.data, C.double(xpos), C.double(ypos))
 }
 
+type KeyCallback func(w *Window, key Key, scancode int, action Action, mods ModifierKey)
+
 //SetKeyCallback sets the key callback which is called when a key is pressed,
 //repeated or released.
 //
@@ -336,28 +338,36 @@ func (w *Window) SetCursorPosition(xpos, ypos float64) {
 //fact that the synthetic ones are generated after the window has lost focus,
 //i.e. Focused will be false and the focus callback will have already been
 //called.
-func (w *Window) SetKeyCallback(cbfun func(w *Window, key Key, scancode int, action Action, mods ModifierKey)) {
+func (w *Window) SetKeyCallback(cbfun KeyCallback) KeyCallback {
+	old := w.fKeyHolder
+	w.fKeyHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetKeyCallback(w.data, nil)
 	} else {
-		w.fKeyHolder = cbfun
 		C.glfwSetKeyCallbackCB(w.data)
 	}
+	return old
 }
+
+type CharacterCallback func(w *Window, char uint)
 
 //SetCharacterCallback sets the character callback which is called when a
 //Unicode character is input.
 //
 //The character callback is intended for text input. If you want to know whether
 //a specific key was pressed or released, use the key callback instead.
-func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
+func (w *Window) SetCharacterCallback(cbfun CharacterCallback) CharacterCallback {
+	old := w.fCharHolder
+	w.fCharHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetCharCallback(w.data, nil)
 	} else {
-		w.fCharHolder = cbfun
 		C.glfwSetCharCallbackCB(w.data)
 	}
+	return old
 }
+
+type MouseButtonCallback func(w *Window, button MouseButton, action Action, mod ModifierKey)
 
 //SetMouseButtonCallback sets the mouse button callback which is called when a
 //mouse button is pressed or released.
@@ -367,47 +377,61 @@ func (w *Window) SetCharacterCallback(cbfun func(w *Window, char uint)) {
 //user-generated events by the fact that the synthetic ones are generated after
 //the window has lost focus, i.e. Focused will be false and the focus
 //callback will have already been called.
-func (w *Window) SetMouseButtonCallback(cbfun func(w *Window, button MouseButton, action Action, mod ModifierKey)) {
+func (w *Window) SetMouseButtonCallback(cbfun MouseButtonCallback) MouseButtonCallback {
+	old := w.fMouseButtonHolder
+	w.fMouseButtonHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetMouseButtonCallback(w.data, nil)
 	} else {
-		w.fMouseButtonHolder = cbfun
 		C.glfwSetMouseButtonCallbackCB(w.data)
 	}
+	return old
 }
+
+type CursorPositionCallback func(w *Window, xpos float64, ypos float64)
 
 //SetCursorPositionCallback sets the cursor position callback which is called
 //when the cursor is moved. The callback is provided with the position relative
 //to the upper-left corner of the client area of the window.
-func (w *Window) SetCursorPositionCallback(cbfun func(w *Window, xpos float64, ypos float64)) {
+func (w *Window) SetCursorPositionCallback(cbfun CursorPositionCallback) CursorPositionCallback {
+	old := w.fCursorPosHolder
+	w.fCursorPosHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetCursorPosCallback(w.data, nil)
 	} else {
-		w.fCursorPosHolder = cbfun
 		C.glfwSetCursorPosCallbackCB(w.data)
 	}
+	return old
 }
+
+type CursorEnterCallback func(w *Window, entered bool)
 
 //SetCursorEnterCallback the cursor boundary crossing callback which is called
 //when the cursor enters or leaves the client area of the window.
-func (w *Window) SetCursorEnterCallback(cbfun func(w *Window, entered bool)) {
+func (w *Window) SetCursorEnterCallback(cbfun CursorEnterCallback) CursorEnterCallback {
+	old := w.fCursorEnterHolder
+	w.fCursorEnterHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetCursorEnterCallback(w.data, nil)
 	} else {
-		w.fCursorEnterHolder = cbfun
 		C.glfwSetCursorEnterCallbackCB(w.data)
 	}
+	return old
 }
+
+type ScrollCallback func(w *Window, xoff float64, yoff float64)
 
 //SetScrollCallback sets the scroll callback which is called when a scrolling
 //device is used, such as a mouse wheel or scrolling area of a touchpad.
-func (w *Window) SetScrollCallback(cbfun func(w *Window, xoff float64, yoff float64)) {
+func (w *Window) SetScrollCallback(cbfun ScrollCallback) ScrollCallback {
+	old := w.fScrollHolder
+	w.fScrollHolder = cbfun
 	if cbfun == nil {
 		C.glfwSetScrollCallback(w.data, nil)
 	} else {
-		w.fScrollHolder = cbfun
 		C.glfwSetScrollCallbackCB(w.data)
 	}
+	return old
 }
 
 //GetJoystickPresent returns whether the specified joystick is present.

--- a/window.go
+++ b/window.go
@@ -421,40 +421,57 @@ func (w *Window) GetUserPointer() unsafe.Pointer {
 	return C.glfwGetWindowUserPointer(w.data)
 }
 
+type PositionCallback func(w *Window, xpos int, ypos int)
+
 //SetPositionCallback sets the position callback of the window, which is called
 //when the window is moved. The callback is provided with the screen position
 //of the upper-left corner of the client area of the window.
-func (w *Window) SetPositionCallback(cbfun func(w *Window, xpos int, ypos int)) {
+func (w *Window) SetPositionCallback(cbfun PositionCallback) PositionCallback {
+	old := w.fPosHolder
+	w.fPosHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowPosCallback(w.data, nil)
 	} else {
-		w.fPosHolder = cbfun
 		C.glfwSetWindowPosCallbackCB(w.data)
 	}
+	return old
 }
+
+type SizeCallback func(w *Window, width int, height int)
 
 //SetSizeCallback sets the size callback of the window, which is called when
 //the window is resized. The callback is provided with the size, in screen
 //coordinates, of the client area of the window.
-func (w *Window) SetSizeCallback(cbfun func(w *Window, width int, height int)) {
+func (w *Window) SetSizeCallback(cbfun SizeCallback) SizeCallback {
+	old := w.fSizeHolder
+	w.fSizeHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowSizeCallback(w.data, nil)
 	} else {
-		w.fSizeHolder = cbfun
 		C.glfwSetWindowSizeCallbackCB(w.data)
 	}
+	return old
 }
+
+type FramebufferSizeCallback func(w *Window, width int, height int)
 
 //SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
 //window, which is called when the framebuffer of the specified window is resized.
-func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, height int)) {
+func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) FramebufferSizeCallback {
+	old := w.fFramebufferSizeHolder
+	w.fFramebufferSizeHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetFramebufferSizeCallback(w.data, nil)
 	} else {
-		w.fFramebufferSizeHolder = cbfun
 		C.glfwSetFramebufferSizeCallbackCB(w.data)
 	}
+	return old
 }
+
+type CloseCallback func(w *Window)
 
 //SetCloseCallback sets the close callback of the window, which is called when
 //the user attempts to close the window, for example by clicking the close
@@ -465,14 +482,19 @@ func (w *Window) SetFramebufferSizeCallback(cbfun func(w *Window, width int, hei
 //
 //Mac OS X: Selecting Quit from the application menu will trigger the close
 //callback for all windows.
-func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
+func (w *Window) SetCloseCallback(cbfun CloseCallback) CloseCallback {
+	old := w.fCloseHolder
+	w.fCloseHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowCloseCallback(w.data, nil)
 	} else {
-		w.fCloseHolder = cbfun
 		C.glfwSetWindowCloseCallbackCB(w.data)
 	}
+	return old
 }
+
+type RefreshCallback func(w *Window)
 
 //SetRefreshCallback sets the refresh callback of the window, which
 //is called when the client area of the window needs to be redrawn, for example
@@ -481,14 +503,19 @@ func (w *Window) SetCloseCallback(cbfun func(w *Window)) {
 //On compositing window systems such as Aero, Compiz or Aqua, where the window
 //contents are saved off-screen, this callback may be called only very
 //infrequently or never at all.
-func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
+func (w *Window) SetRefreshCallback(cbfun RefreshCallback) RefreshCallback {
+	old := w.fRefreshHolder
+	w.fRefreshHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowRefreshCallback(w.data, nil)
 	} else {
-		w.fRefreshHolder = cbfun
 		C.glfwSetWindowRefreshCallbackCB(w.data)
 	}
+	return old
 }
+
+type FocusCallback func(w *Window, focused bool)
 
 //SetFocusCallback sets the focus callback of the window, which is called when
 //the window gains or loses focus.
@@ -496,24 +523,32 @@ func (w *Window) SetRefreshCallback(cbfun func(w *Window)) {
 //After the focus callback is called for a window that lost focus, synthetic key
 //and mouse button release events will be generated for all such that had been
 //pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
-func (w *Window) SetFocusCallback(cbfun func(w *Window, focused bool)) {
+func (w *Window) SetFocusCallback(cbfun FocusCallback) FocusCallback {
+	old := w.fFocusHolder
+	w.fFocusHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowFocusCallback(w.data, nil)
 	} else {
-		w.fFocusHolder = cbfun
 		C.glfwSetWindowFocusCallbackCB(w.data)
 	}
+	return old
 }
+
+type IconifyCallback func(w *Window, iconified bool)
 
 //SetIconifyCallback sets the iconification callback of the window, which is
 //called when the window is iconified or restored.
-func (w *Window) SetIconifyCallback(cbfun func(w *Window, iconified bool)) {
+func (w *Window) SetIconifyCallback(cbfun IconifyCallback) IconifyCallback {
+	old := w.fIconifyHolder
+	w.fIconifyHolder = cbfun
+
 	if cbfun == nil {
 		C.glfwSetWindowIconifyCallback(w.data, nil)
 	} else {
-		w.fIconifyHolder = cbfun
 		C.glfwSetWindowIconifyCallbackCB(w.data)
 	}
+	return old
 }
 
 //PollEvents processes only those events that have already been received and


### PR DESCRIPTION
My motivation here is to make it possible to have reusable
pieces of code which you can plug in just by feeding it the
`*glfw.Window`. The reusable pieces would be called last and
they could record the previous callback and call it, forming
a callback chain.

The sort of thing you could do is implement a camera system
where you only need one function call to specify the window
and another to get the transformation matrix.

Strictly speaking, this is an API-change. However, I haven't
managed to find any examples that don't compile correctly after
this change yet, so I'm not sure if it counts as an 
API-breaking-change.

@tapir @shurcooL
