### PR TITLE
Added compiler flags for darwin to locate GLFW

### DIFF
--- a/clipboard.go
+++ b/clipboard.go
@@ -1,5 +1,7 @@
 package glfw3
 
+//#cgo darwin CFLAGS: -I/usr/local/include
+//#cgo darwin LDFLAGS: -L/usr/local/lib 
 //#include <stdlib.h>
 //#include <GLFW/glfw3.h>
 import "C"


### PR DESCRIPTION
The GLFW/ include path wasn't being found.
I had installed (avoiding brew) the library on /usr/local
OS X 10.9.4
gcc 4.2.1
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
