### PR TITLE
Fix build with mingw-w64

### DIFF
--- a/glfw_win32_init.c
+++ b/glfw_win32_init.c
@@ -13,9 +13,12 @@
 	}
 	#endif
 	
+	// _get_output_format is described at MSDN:
 	// http://msdn.microsoft.com/en-us/library/571yb472.aspx
-	#include <stdio.h>
-	#ifndef _get_output_format
+	//
+	// MinGW32 does not define it. But MinGW-W64 does. Unlike strdup above
+	// compilers don't #define _get_output_format if it exists.
+	#ifndef __MINGW64__
 	unsigned int _get_output_format(void) {
 		return 0;
 	};


### PR DESCRIPTION
Please see https://github.com/go-gl/glfw3/issues/82#issuecomment-53967629

With this change I can verify that the package now builds with both MinGW-32 and MinGW-W64 on a windows/amd64 machine.
