### PR TITLE
Fix error handling deadlock.

### DIFF
--- a/error.go
+++ b/error.go
@@ -38,6 +38,7 @@ var lastError = make(chan *GLFWError, 1)
 
 //export goErrorCB
 func goErrorCB(code C.int, desc *C.char) {
+	flushErrors()
 	err := &GLFWError{ErrorCode(code), C.GoString(desc)}
 	select {
 	case lastError <- err:

--- a/error.go
+++ b/error.go
@@ -43,7 +43,8 @@ func goErrorCB(code C.int, desc *C.char) {
 	select {
 	case lastError <- err:
 	default:
-		fmt.Printf("GLFW: Uncaught error: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: an uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
 }
 
@@ -63,7 +64,8 @@ func init() {
 func flushErrors() {
 	select {
 	case err := <-lastError:
-		fmt.Printf("GLFW: Uncaught error: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: an uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	default:
 	}
 }

--- a/error.go
+++ b/error.go
@@ -43,7 +43,7 @@ func goErrorCB(code C.int, desc *C.char) {
 	select {
 	case lastError <- err:
 	default:
-		fmt.Printf("GLFW: an uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
 }
@@ -64,7 +64,7 @@ func init() {
 func flushErrors() {
 	select {
 	case err := <-lastError:
-		fmt.Printf("GLFW: an uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	default:
 	}

--- a/error.go
+++ b/error.go
@@ -30,12 +30,20 @@ type GLFWError struct {
 	Desc string
 }
 
+// Note: There are many cryptic caveats to proper error handling here.
+// See: https://github.com/go-gl/glfw3/pull/86
+
 // Holds the value of the last error
 var lastError = make(chan *GLFWError, 1)
 
 //export goErrorCB
 func goErrorCB(code C.int, desc *C.char) {
-	lastError <- &GLFWError{ErrorCode(code), C.GoString(desc)}
+	err := &GLFWError{ErrorCode(code), C.GoString(desc)}
+	select {
+	case lastError <- err:
+	default:
+		fmt.Printf("GLFW: Uncaught error: %d -> %s\n", err.Code, err.Desc)
+	}
 }
 
 // Error prints the error code and description in a readable format.
@@ -46,4 +54,15 @@ func (e *GLFWError) Error() string {
 // Set the glfw callback internally
 func init() {
 	C.glfwSetErrorCallbackCB()
+}
+
+// flushErrors is called by Terminate before it actually calls C.glfwTerminate,
+// this ensures that any uncaught errors buffered in lastError are printed
+// before the program exits.
+func flushErrors() {
+	select {
+	case err := <-lastError:
+		fmt.Printf("GLFW: Uncaught error: %d -> %s\n", err.Code, err.Desc)
+	default:
+	}
 }

--- a/glfw.go
+++ b/glfw.go
@@ -46,6 +46,7 @@ func Init() error {
 //
 // This function may only be called from the main thread.
 func Terminate() {
+	flushErrors()
 	C.glfwTerminate()
 }
 


### PR DESCRIPTION
@tapir and @shurcooL PTAL and let me know what you think.

This is an alternative fix for #92 (see most discussion in #86).

The original test program would output:

```
App started
Error 65540: Invalid window size
Error 65540: Invalid window size
GLFW: Uncaught error: 65539 -> Invalid argument for enum parameter
No deadlock
```

Which of course is incorrect (you should see two uncaught errors). Instead, we make it such that a call to Terminate flushes the pending errors so they are printed properly before the program exits.

The original test program (incorrectly) did not invoke Terminate, so a proper version is provided:

``` Go
package main

import (
    "runtime"
    "fmt"
    glfw "github.com/go-gl/glfw3"
)

func init() {
    runtime.LockOSThread()
}

func main() {
    glfw.Init()

    fmt.Println("App started")

    // Here is an error that is caught
    _, err := glfw.CreateWindow(-5473548, 2354234, "Testing", nil, nil)
    if err != nil {
        fmt.Println(err)
    }

    // Here is another error that is caught
    _, err = glfw.CreateWindow(-5473548, 2354234, "Testing", nil, nil)
    if err != nil {
        fmt.Println(err)
    }

    // Here is two uncaught errors
    glfw.WindowHint(-23123, 0)
    glfw.WindowHint(-23123, 0)

    glfw.Terminate()

    fmt.Println("No deadlock")
}
```

Which when ran has the correct output:

```
App started
Error 65540: Invalid window size
Error 65540: Invalid window size
GLFW: Uncaught error: 65539 -> Invalid argument for enum parameter
GLFW: Uncaught error: 65539 -> Invalid argument for enum parameter
No deadlock
```

It's OK that we require users to invoke Terminate to get correct output; as GLFW itself already requires this. If you don't invoke Terminate for instance the monitors gamma/resolution/etc may not be set back to correct values; _a program not invoking Terminate is an incorrect program period._

This doesn't solve the fact that each GLFW function still needs to return an error for proper handling -- but this solves the immediate deadlock issue and doesn't suffer from the (implicit) data races in #92.
