### PR TITLE
devel_glfw3.1: Return errors

### DIFF
--- a/context.go
+++ b/context.go
@@ -12,29 +12,32 @@ import (
 // Originally GLFW 3 passes a null pointer to detach the context.
 // But since we're using receievers, DetachCurrentContext should
 // be used instead.
-func (w *Window) MakeContextCurrent() {
+func (w *Window) MakeContextCurrent() error {
 	C.glfwMakeContextCurrent(w.data)
+	return fetchError()
 }
 
 // DetachCurrentContext detaches the current context.
-func DetachCurrentContext() {
+func DetachCurrentContext() error {
 	C.glfwMakeContextCurrent(nil)
+	return fetchError()
 }
 
 // GetCurrentContext returns the window whose context is current.
-func GetCurrentContext() *Window {
+func GetCurrentContext() (*Window, error) {
 	w := C.glfwGetCurrentContext()
 	if w == nil {
-		return nil
+		return nil, fetchError()
 	}
-	return windows.get(w)
+	return windows.get(w), nil
 }
 
 // SwapBuffers swaps the front and back buffers of the window. If the
 // swap interval is greater than zero, the GPU driver waits the specified number
 // of screen updates before swapping the buffers.
-func (w *Window) SwapBuffers() {
+func (w *Window) SwapBuffers() error {
 	C.glfwSwapBuffers(w.data)
+	return fetchError()
 }
 
 // SwapInterval sets the swap interval for the current context, i.e. the number
@@ -51,8 +54,9 @@ func (w *Window) SwapBuffers() {
 //
 // Some GPU drivers do not honor the requested swap interval, either because of
 // user settings that override the request or due to bugs in the driver.
-func SwapInterval(interval int) {
+func SwapInterval(interval int) error {
 	C.glfwSwapInterval(C.int(interval))
+	return fetchError()
 }
 
 // ExtensionSupported returns whether the specified OpenGL or context creation
@@ -63,8 +67,8 @@ func SwapInterval(interval int) {
 // recommended that you cache its results if it's going to be used frequently.
 // The extension strings will not change during the lifetime of a context, so
 // there is no danger in doing this.
-func ExtensionSupported(extension string) bool {
+func ExtensionSupported(extension string) (bool, error) {
 	e := C.CString(extension)
 	defer C.free(unsafe.Pointer(e))
-	return glfwbool(C.glfwExtensionSupported(e))
+	return glfwbool(C.glfwExtensionSupported(e)), fetchError()
 }

--- a/error.go
+++ b/error.go
@@ -62,8 +62,9 @@ func init() {
 // this ensures that any uncaught errors buffered in lastError are printed
 // before the program exits.
 func flushErrors() {
-	err := fetchError()
-	if err != nil {
+	e := fetchError()
+	if e != nil {
+		err := e.(*GLFWError)
 		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
@@ -72,7 +73,7 @@ func flushErrors() {
 // fetchError is called by various functions to retrieve the error that might
 // have occured from a generic GLFW operation. It returns nil if no error is
 // present.
-func fetchError() *GLFWError {
+func fetchError() error {
 	select {
 	case err := <-lastError:
 		return err

--- a/error.go
+++ b/error.go
@@ -62,10 +62,9 @@ func init() {
 // this ensures that any uncaught errors buffered in lastError are printed
 // before the program exits.
 func flushErrors() {
-	e := fetchError()
-	if e != nil {
-		err := e.(*GLFWError)
-		fmt.Printf("GLFW: An uncaught error has occurred: %d -> %s\n", err.Code, err.Desc)
+	err := fetchError()
+	if err != nil {
+		fmt.Println("GLFW: An uncaught error has occurred:", err)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
 }

--- a/error.go
+++ b/error.go
@@ -43,7 +43,7 @@ func goErrorCB(code C.int, desc *C.char) {
 	select {
 	case lastError <- err:
 	default:
-		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: An uncaught error has occurred: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
 }
@@ -65,13 +65,13 @@ func flushErrors() {
 	e := fetchError()
 	if e != nil {
 		err := e.(*GLFWError)
-		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
+		fmt.Printf("GLFW: An uncaught error has occurred: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
 	}
 }
 
 // fetchError is called by various functions to retrieve the error that might
-// have occured from a generic GLFW operation. It returns nil if no error is
+// have occurred from a generic GLFW operation. It returns nil if no error is
 // present.
 func fetchError() error {
 	select {

--- a/error.go
+++ b/error.go
@@ -78,6 +78,6 @@ func fetchError() error {
 	case err := <-lastError:
 		return err
 	default:
+		return nil
 	}
-	return nil
 }

--- a/error.go
+++ b/error.go
@@ -62,10 +62,21 @@ func init() {
 // this ensures that any uncaught errors buffered in lastError are printed
 // before the program exits.
 func flushErrors() {
-	select {
-	case err := <-lastError:
+	err := fetchError()
+	if err != nil {
 		fmt.Printf("GLFW: An uncaught error has occured: %d -> %s\n", err.Code, err.Desc)
 		fmt.Println("GLFW: Please report this bug in the Go package immediately.")
+	}
+}
+
+// fetchError is called by various functions to retrieve the error that might
+// have occured from a generic GLFW operation. It returns nil if no error is
+// present.
+func fetchError() *GLFWError {
+	select {
+	case err := <-lastError:
+		return err
 	default:
 	}
+	return nil
 }

--- a/glfw.go
+++ b/glfw.go
@@ -29,10 +29,8 @@ const (
 //
 // This function may only be called from the main thread.
 func Init() error {
-	if glfwbool(C.glfwInit()) {
-		return nil
-	}
-	return <-lastError
+	C.glfwInit()
+	return fetchError()
 }
 
 // Terminate destroys all remaining windows, frees any allocated resources and

--- a/glfw.go
+++ b/glfw.go
@@ -45,9 +45,11 @@ func Init() error {
 // this function, as it is called by Init before it returns failure.
 //
 // This function may only be called from the main thread.
-func Terminate() {
+func Terminate() error {
+	err := fetchError()
 	flushErrors()
 	C.glfwTerminate()
+	return err
 }
 
 // GetVersion retrieves the major, minor and revision numbers of the GLFW

--- a/monitor.go
+++ b/monitor.go
@@ -55,7 +55,7 @@ func GetMonitors() ([]*Monitor, error) {
 
 	mC := C.glfwGetMonitors((*C.int)(unsafe.Pointer(&length)))
 	if mC == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 
 	m := make([]*Monitor, length)
@@ -72,7 +72,7 @@ func GetMonitors() ([]*Monitor, error) {
 func GetPrimaryMonitor() (*Monitor, error) {
 	m := C.glfwGetPrimaryMonitor()
 	if m == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 	return &Monitor{m}, nil
 }
@@ -101,7 +101,7 @@ func (m *Monitor) GetPhysicalSize() (width, height int, err error) {
 func (m *Monitor) GetName() (string, error) {
 	mn := C.glfwGetMonitorName(m.data)
 	if mn == nil {
-		return "", <-lastError
+		return "", fetchError()
 	}
 	return C.GoString(mn), nil
 }
@@ -128,7 +128,7 @@ func (m *Monitor) GetVideoModes() ([]*VideoMode, error) {
 
 	vC := C.glfwGetVideoModes(m.data, (*C.int)(unsafe.Pointer(&length)))
 	if vC == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 
 	v := make([]*VideoMode, length)
@@ -147,7 +147,7 @@ func (m *Monitor) GetVideoModes() ([]*VideoMode, error) {
 func (m *Monitor) GetVideoMode() (*VideoMode, error) {
 	t := C.glfwGetVideoMode(m.data)
 	if t == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 	return &VideoMode{int(t.width), int(t.height), int(t.redBits), int(t.greenBits), int(t.blueBits), int(t.refreshRate)}, nil
 }
@@ -165,7 +165,7 @@ func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 
 	rampC := C.glfwGetGammaRamp(m.data)
 	if rampC == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 
 	length := int(rampC.size)

--- a/monitor.go
+++ b/monitor.go
@@ -79,10 +79,10 @@ func GetPrimaryMonitor() (*Monitor, error) {
 
 // GetPosition returns the position, in screen coordinates, of the upper-left
 // corner of the monitor.
-func (m *Monitor) GetPosition() (x, y int) {
+func (m *Monitor) GetPosition() (x, y int, err error) {
 	var xpos, ypos C.int
 	C.glfwGetMonitorPos(m.data, &xpos, &ypos)
-	return int(xpos), int(ypos)
+	return int(xpos), int(ypos), fetchError()
 }
 
 // GetPhysicalSize returns the size, in millimetres, of the display area of the
@@ -91,10 +91,10 @@ func (m *Monitor) GetPosition() (x, y int) {
 // Note: Some operating systems do not provide accurate information, either
 // because the monitor's EDID data is incorrect, or because the driver does not
 // report it accurately.
-func (m *Monitor) GetPhysicalSize() (width, height int) {
+func (m *Monitor) GetPhysicalSize() (width, height int, err error) {
 	var wi, h C.int
 	C.glfwGetMonitorPhysicalSize(m.data, &wi, &h)
-	return int(wi), int(h)
+	return int(wi), int(h), fetchError()
 }
 
 // GetName returns a human-readable name of the monitor, encoded as UTF-8.
@@ -109,13 +109,14 @@ func (m *Monitor) GetName() (string, error) {
 // SetMonitorCallback sets the monitor configuration callback, or removes the
 // currently set callback. This is called when a monitor is connected to or
 // disconnected from the system.
-func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) {
+func SetMonitorCallback(cbfun func(monitor *Monitor, event MonitorEvent)) error {
 	if cbfun == nil {
 		C.glfwSetMonitorCallback(nil)
 	} else {
 		fMonitorHolder = cbfun
 		C.glfwSetMonitorCallbackCB()
 	}
+	return fetchError()
 }
 
 // GetVideoModes returns an array of all video modes supported by the monitor.
@@ -153,8 +154,9 @@ func (m *Monitor) GetVideoMode() (*VideoMode, error) {
 
 // SetGamma generates a 256-element gamma ramp from the specified exponent and then calls
 // SetGamma with it.
-func (m *Monitor) SetGamma(gamma float32) {
+func (m *Monitor) SetGamma(gamma float32) error {
 	C.glfwSetGamma(m.data, C.float(gamma))
+	return fetchError()
 }
 
 // GetGammaRamp retrieves the current gamma ramp of the monitor.
@@ -181,7 +183,7 @@ func (m *Monitor) GetGammaRamp() (*GammaRamp, error) {
 }
 
 // SetGammaRamp sets the current gamma ramp for the monitor.
-func (m *Monitor) SetGammaRamp(ramp *GammaRamp) {
+func (m *Monitor) SetGammaRamp(ramp *GammaRamp) error {
 	var rampC C.GLFWgammaramp
 
 	length := len(ramp.Red)
@@ -193,4 +195,5 @@ func (m *Monitor) SetGammaRamp(ramp *GammaRamp) {
 	}
 
 	C.glfwSetGammaRamp(m.data, &rampC)
+	return fetchError()
 }

--- a/native_darwin.go
+++ b/native_darwin.go
@@ -8,11 +8,11 @@ import "C"
 
 // See: https://github.com/go-gl/glfw3/issues/82
 /*
-func (w *Window) GetCocoaWindow() C.id {
-	return C.glfwGetCocoaWindow(w.data)
+func (w *Window) GetCocoaWindow() (C.id, error) {
+	return C.glfwGetCocoaWindow(w.data), fetchError()
 }
 
-func (w *Window) GetNSGLContext() C.id {
-	return C.glfwGetNSGLContext(w.data)
+func (w *Window) GetNSGLContext() (C.id, error) {
+	return C.glfwGetNSGLContext(w.data), fetchError()
 }
 */

--- a/native_linbsd.go
+++ b/native_linbsd.go
@@ -8,14 +8,14 @@ package glfw3
 //#include "glfw/include/GLFW/glfw3native.h"
 import "C"
 
-func (w *Window) GetX11Window() C.Window {
-	return C.glfwGetX11Window(w.data)
+func (w *Window) GetX11Window() (C.Window, error) {
+	return C.glfwGetX11Window(w.data), fetchError()
 }
 
-func (w *Window) GetGLXContext() C.GLXContext {
-	return C.glfwGetGLXContext(w.data)
+func (w *Window) GetGLXContext() (C.GLXContext, error) {
+	return C.glfwGetGLXContext(w.data), fetchError()
 }
 
-func GetX11Display() *C.Display {
-	return C.glfwGetX11Display()
+func GetX11Display() (*C.Display, error) {
+	return C.glfwGetX11Display(), fetchError()
 }

--- a/native_windows.go
+++ b/native_windows.go
@@ -6,10 +6,10 @@ package glfw3
 //#include "glfw/include/GLFW/glfw3native.h"
 import "C"
 
-func (w *Window) GetWin32Window() C.HWND {
-	return C.glfwGetWin32Window(w.data)
+func (w *Window) GetWin32Window() (C.HWND, error) {
+	return C.glfwGetWin32Window(w.data), fetchError()
 }
 
-func (w *Window) GetWGLContext() C.HGLRC {
-	return C.glfwGetWGLContext(w.data)
+func (w *Window) GetWGLContext() (C.HGLRC, error) {
+	return C.glfwGetWGLContext(w.data), fetchError()
 }

--- a/time.go
+++ b/time.go
@@ -10,11 +10,7 @@ import "C"
 // of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
 // source on each supported platform.
 func GetTime() (float64, error) {
-	r := float64(C.glfwGetTime())
-	if r == 0 {
-		return 0, <-lastError
-	}
-	return r, nil
+	return float64(C.glfwGetTime()), fetchError()
 }
 
 // SetTime sets the value of the GLFW timer. It then continues to count up from

--- a/time.go
+++ b/time.go
@@ -23,6 +23,7 @@ func GetTime() (float64, error) {
 // The resolution of the timer is system dependent, but is usually on the order
 // of a few micro- or nanoseconds. It uses the highest-resolution monotonic time
 // source on each supported platform.
-func SetTime(time float64) {
+func SetTime(time float64) error {
 	C.glfwSetTime(C.double(time))
+	return fetchError()
 }

--- a/window.go
+++ b/window.go
@@ -251,7 +251,7 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 
 	w := C.glfwCreateWindow(C.int(width), C.int(height), t, m, s)
 	if w == nil {
-		return nil, <-lastError
+		return nil, fetchError()
 	}
 
 	wnd := &Window{data: w}
@@ -407,11 +407,7 @@ func (w *Window) GetMonitor() (*Monitor, error) {
 // GetAttribute returns an attribute of the window. There are many attributes,
 // some related to the window and others to its context.
 func (w *Window) GetAttribute(attrib Hint) (int, error) {
-	r := int(C.glfwGetWindowAttrib(w.data, C.int(attrib)))
-	if r == 0 {
-		return 0, <-lastError
-	}
-	return r, nil
+	return int(C.glfwGetWindowAttrib(w.data, C.int(attrib))), fetchError()
 }
 
 // SetUserPointer sets the user-defined pointer of the window. The current value
@@ -568,7 +564,7 @@ func (w *Window) SetClipboardString(str string) error {
 func (w *Window) GetClipboardString() (string, error) {
 	cs := C.glfwGetClipboardString(w.data)
 	if cs == nil {
-		return "", <-lastError
+		return "", fetchError()
 	}
 	return C.GoString(cs), nil
 }

--- a/window.go
+++ b/window.go
@@ -186,8 +186,9 @@ func goWindowIconifyCB(window unsafe.Pointer, iconified C.int) {
 // DefaultHints resets all window hints to their default values.
 //
 // This function may only be called from the main thread.
-func DefaultWindowHints() {
+func DefaultWindowHints() error {
 	C.glfwDefaultWindowHints()
+	return fetchError()
 }
 
 // Hint function sets hints for the next call to CreateWindow. The hints,
@@ -195,8 +196,9 @@ func DefaultWindowHints() {
 // DefaultHints, or until the library is terminated with Terminate.
 //
 // This function may only be called from the main thread.
-func WindowHint(target Hint, hint int) {
+func WindowHint(target Hint, hint int) error {
 	C.glfwWindowHint(C.int(target), C.int(hint))
+	return fetchError()
 }
 
 // CreateWindow creates a window and its associated context. Most of the options
@@ -261,42 +263,45 @@ func CreateWindow(width, height int, title string, monitor *Monitor, share *Wind
 // function, no further callbacks will be called for that window.
 //
 // This function may only be called from the main thread.
-func (w *Window) Destroy() {
+func (w *Window) Destroy() error {
 	windows.remove(w.data)
 	C.glfwDestroyWindow(w.data)
+	return fetchError()
 }
 
 // ShouldClose returns the value of the close flag of the specified window.
-func (w *Window) ShouldClose() bool {
-	return glfwbool(C.glfwWindowShouldClose(w.data))
+func (w *Window) ShouldClose() (bool, error) {
+	return glfwbool(C.glfwWindowShouldClose(w.data)), fetchError()
 }
 
 // SetShouldClose sets the value of the close flag of the window. This can be
 // used to override the user's attempt to close the window, or to signal that it
 // should be closed.
-func (w *Window) SetShouldClose(value bool) {
+func (w *Window) SetShouldClose(value bool) error {
 	if !value {
 		C.glfwSetWindowShouldClose(w.data, C.GL_FALSE)
 	} else {
 		C.glfwSetWindowShouldClose(w.data, C.GL_TRUE)
 	}
+	return fetchError()
 }
 
 // SetTitle sets the window title, encoded as UTF-8, of the window.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetTitle(title string) {
+func (w *Window) SetTitle(title string) error {
 	t := C.CString(title)
 	defer C.free(unsafe.Pointer(t))
 	C.glfwSetWindowTitle(w.data, t)
+	return fetchError()
 }
 
 // GetPosition returns the position, in screen coordinates, of the upper-left
 // corner of the client area of the window.
-func (w *Window) GetPosition() (x, y int) {
+func (w *Window) GetPosition() (x, y int, err error) {
 	var xpos, ypos C.int
 	C.glfwGetWindowPos(w.data, &xpos, &ypos)
-	return int(xpos), int(ypos)
+	return int(xpos), int(ypos), fetchError()
 }
 
 // SetPosition sets the position, in screen coordinates, of the upper-left corner
@@ -313,16 +318,17 @@ func (w *Window) GetPosition() (x, y int) {
 // The window manager may put limits on what positions are allowed.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetPosition(xpos, ypos int) {
+func (w *Window) SetPosition(xpos, ypos int) error {
 	C.glfwSetWindowPos(w.data, C.int(xpos), C.int(ypos))
+	return fetchError()
 }
 
 // GetSize returns the size, in screen coordinates, of the client area of the
 // specified window.
-func (w *Window) GetSize() (width, height int) {
+func (w *Window) GetSize() (width, height int, err error) {
 	var wi, h C.int
 	C.glfwGetWindowSize(w.data, &wi, &h)
-	return int(wi), int(h)
+	return int(wi), int(h), fetchError()
 }
 
 // SetSize sets the size, in screen coordinates, of the client area of the
@@ -335,16 +341,17 @@ func (w *Window) GetSize() (width, height int) {
 // The window manager may put limits on what window sizes are allowed.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetSize(width, height int) {
+func (w *Window) SetSize(width, height int) error {
 	C.glfwSetWindowSize(w.data, C.int(width), C.int(height))
+	return fetchError()
 }
 
 // GetFramebufferSize retrieves the size, in pixels, of the framebuffer of the
 // specified window.
-func (w *Window) GetFramebufferSize() (width, height int) {
+func (w *Window) GetFramebufferSize() (width, height int, err error) {
 	var wi, h C.int
 	C.glfwGetFramebufferSize(w.data, &wi, &h)
-	return int(wi), int(h)
+	return int(wi), int(h), fetchError()
 }
 
 // Iconfiy iconifies/minimizes the window, if it was previously restored. If it
@@ -353,8 +360,9 @@ func (w *Window) GetFramebufferSize() (width, height int) {
 // nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Iconify() {
+func (w *Window) Iconify() error {
 	C.glfwIconifyWindow(w.data)
+	return fetchError()
 }
 
 // Restore restores the window, if it was previously iconified/minimized. If it
@@ -363,34 +371,37 @@ func (w *Window) Iconify() {
 // nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Restore() {
+func (w *Window) Restore() error {
 	C.glfwRestoreWindow(w.data)
+	return fetchError()
 }
 
 // Show makes the window visible, if it was previously hidden. If the window is
 // already visible or is in full screen mode, this function does nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Show() {
+func (w *Window) Show() error {
 	C.glfwShowWindow(w.data)
+	return fetchError()
 }
 
 // Hide hides the window, if it was previously visible. If the window is already
 // hidden or is in full screen mode, this function does nothing.
 //
 // This function may only be called from the main thread.
-func (w *Window) Hide() {
+func (w *Window) Hide() error {
 	C.glfwHideWindow(w.data)
+	return fetchError()
 }
 
 // GetMonitor returns the handle of the monitor that the window is in
 // fullscreen on.
-func (w *Window) GetMonitor() *Monitor {
+func (w *Window) GetMonitor() (*Monitor, error) {
 	m := C.glfwGetWindowMonitor(w.data)
 	if m == nil {
-		return nil
+		return nil, fetchError()
 	}
-	return &Monitor{m}
+	return &Monitor{m}, nil
 }
 
 // GetAttribute returns an attribute of the window. There are many attributes,
@@ -405,14 +416,15 @@ func (w *Window) GetAttribute(attrib Hint) (int, error) {
 
 // SetUserPointer sets the user-defined pointer of the window. The current value
 // is retained until the window is destroyed. The initial value is nil.
-func (w *Window) SetUserPointer(pointer unsafe.Pointer) {
+func (w *Window) SetUserPointer(pointer unsafe.Pointer) error {
 	C.glfwSetWindowUserPointer(w.data, pointer)
+	return fetchError()
 }
 
 // GetUserPointer returns the current value of the user-defined pointer of the
 // window. The initial value is nil.
-func (w *Window) GetUserPointer() unsafe.Pointer {
-	return C.glfwGetWindowUserPointer(w.data)
+func (w *Window) GetUserPointer() (unsafe.Pointer, error) {
+	return C.glfwGetWindowUserPointer(w.data), fetchError()
 }
 
 type PositionCallback func(w *Window, xpos int, ypos int)
@@ -420,7 +432,7 @@ type PositionCallback func(w *Window, xpos int, ypos int)
 // SetPositionCallback sets the position callback of the window, which is called
 // when the window is moved. The callback is provided with the screen position
 // of the upper-left corner of the client area of the window.
-func (w *Window) SetPositionCallback(cbfun PositionCallback) (previous PositionCallback) {
+func (w *Window) SetPositionCallback(cbfun PositionCallback) (previous PositionCallback, err error) {
 	previous = w.fPosHolder
 	w.fPosHolder = cbfun
 	if cbfun == nil {
@@ -428,7 +440,7 @@ func (w *Window) SetPositionCallback(cbfun PositionCallback) (previous PositionC
 	} else {
 		C.glfwSetWindowPosCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type SizeCallback func(w *Window, width int, height int)
@@ -436,7 +448,7 @@ type SizeCallback func(w *Window, width int, height int)
 // SetSizeCallback sets the size callback of the window, which is called when
 // the window is resized. The callback is provided with the size, in screen
 // coordinates, of the client area of the window.
-func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback) {
+func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback, err error) {
 	previous = w.fSizeHolder
 	w.fSizeHolder = cbfun
 	if cbfun == nil {
@@ -444,14 +456,14 @@ func (w *Window) SetSizeCallback(cbfun SizeCallback) (previous SizeCallback) {
 	} else {
 		C.glfwSetWindowSizeCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type FramebufferSizeCallback func(w *Window, width int, height int)
 
 // SetFramebufferSizeCallback sets the framebuffer resize callback of the specified
 // window, which is called when the framebuffer of the specified window is resized.
-func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (previous FramebufferSizeCallback) {
+func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (previous FramebufferSizeCallback, err error) {
 	previous = w.fFramebufferSizeHolder
 	w.fFramebufferSizeHolder = cbfun
 	if cbfun == nil {
@@ -459,7 +471,7 @@ func (w *Window) SetFramebufferSizeCallback(cbfun FramebufferSizeCallback) (prev
 	} else {
 		C.glfwSetFramebufferSizeCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type CloseCallback func(w *Window)
@@ -473,7 +485,7 @@ type CloseCallback func(w *Window)
 //
 // Mac OS X: Selecting Quit from the application menu will trigger the close
 // callback for all windows.
-func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback) {
+func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback, err error) {
 	previous = w.fCloseHolder
 	w.fCloseHolder = cbfun
 	if cbfun == nil {
@@ -481,7 +493,7 @@ func (w *Window) SetCloseCallback(cbfun CloseCallback) (previous CloseCallback) 
 	} else {
 		C.glfwSetWindowCloseCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type RefreshCallback func(w *Window)
@@ -493,7 +505,7 @@ type RefreshCallback func(w *Window)
 // On compositing window systems such as Aero, Compiz or Aqua, where the window
 // contents are saved off-screen, this callback may be called only very
 // infrequently or never at all.
-func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCallback) {
+func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCallback, err error) {
 	previous = w.fRefreshHolder
 	w.fRefreshHolder = cbfun
 	if cbfun == nil {
@@ -501,7 +513,7 @@ func (w *Window) SetRefreshCallback(cbfun RefreshCallback) (previous RefreshCall
 	} else {
 		C.glfwSetWindowRefreshCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type FocusCallback func(w *Window, focused bool)
@@ -512,7 +524,7 @@ type FocusCallback func(w *Window, focused bool)
 // After the focus callback is called for a window that lost focus, synthetic key
 // and mouse button release events will be generated for all such that had been
 // pressed. For more information, see SetKeyCallback and SetMouseButtonCallback.
-func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback) {
+func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback, err error) {
 	previous = w.fFocusHolder
 	w.fFocusHolder = cbfun
 	if cbfun == nil {
@@ -520,14 +532,14 @@ func (w *Window) SetFocusCallback(cbfun FocusCallback) (previous FocusCallback) 
 	} else {
 		C.glfwSetWindowFocusCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 type IconifyCallback func(w *Window, iconified bool)
 
 // SetIconifyCallback sets the iconification callback of the window, which is
 // called when the window is iconified or restored.
-func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCallback) {
+func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCallback, err error) {
 	previous = w.fIconifyHolder
 	w.fIconifyHolder = cbfun
 	if cbfun == nil {
@@ -535,17 +547,18 @@ func (w *Window) SetIconifyCallback(cbfun IconifyCallback) (previous IconifyCall
 	} else {
 		C.glfwSetWindowIconifyCallbackCB(w.data)
 	}
-	return previous
+	return previous, fetchError()
 }
 
 // SetClipboardString sets the system clipboard to the specified UTF-8 encoded
 // string.
 //
 // This function may only be called from the main thread.
-func (w *Window) SetClipboardString(str string) {
+func (w *Window) SetClipboardString(str string) error {
 	cp := C.CString(str)
 	defer C.free(unsafe.Pointer(cp))
 	C.glfwSetClipboardString(w.data, cp)
+	return fetchError()
 }
 
 // GetClipboardString returns the contents of the system clipboard, if it
@@ -569,8 +582,9 @@ func (w *Window) GetClipboardString() (string, error) {
 // This function may not be called from a callback.
 //
 // This function may only be called from the main thread.
-func PollEvents() {
+func PollEvents() error {
 	C.glfwPollEvents()
+	return fetchError()
 }
 
 // WaitEvents puts the calling thread to sleep until at least one event has been
@@ -586,8 +600,9 @@ func PollEvents() {
 // This function may not be called from a callback.
 //
 // This function may only be called from the main thread.
-func WaitEvents() {
+func WaitEvents() error {
 	C.glfwWaitEvents()
+	return fetchError()
 }
 
 // PostEmptyEvent posts an empty event from the current thread to the main
@@ -598,6 +613,7 @@ func WaitEvents() {
 // your threading library of choice.
 //
 // This function may be called from secondary threads.
-func PostEmptyEvent() {
+func PostEmptyEvent() error {
 	C.glfwPostEmptyEvent()
+	return fetchError()
 }


### PR DESCRIPTION
The first commit causes every GLFW function to return an error. The second commit streamlines the error handling process by making use of the new `fetchError` function in place of `<-lastError`.
