### PR TITLE
devel_glfw3.1 branch: Fix Linux build by adding missing linker library.

### DIFF
--- a/build.go
+++ b/build.go
@@ -34,8 +34,8 @@ package glfw3
 #cgo linux,wayland CFLAGS: -D_GLFW_WAYLAND -D_GLFW_EGL -D_GLFW_HAS_DLOPEN
 
 // Linker Options:
-#cgo linux,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm
-#cgo linux,wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm
+#cgo linux,!wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama
+#cgo linux,wayland LDFLAGS: -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama
 
 
 // FreeBSD Build Tags


### PR DESCRIPTION
The Xinerama library was added in glfw/glfw@4918514eafd620f63916c62c82a5c67636f64848 and appears to be a mandatory library for both non-Wayland and Wayland paths.

Fixes the following issue:

```
ubuntu@ubuntu:~$ go get -u github.com/shurcooL/glfw3
# github.com/shurcooL/glfw3
/tmp/go-build359803230/github.com/shurcooL/glfw3/_obj/glfw_x11_init.o: In function `initExtensions':
MyGoWorkspace/src/github.com/shurcooL/glfw3/glfw/src/x11_init.c:538: undefined reference to `XineramaQueryExtension'
MyGoWorkspace/src/github.com/shurcooL/glfw3/glfw/src/x11_init.c:542: undefined reference to `XineramaIsActive'
/tmp/go-build359803230/github.com/shurcooL/glfw3/_obj/glfw_x11_monitor.o: In function `_glfwPlatformGetMonitors':
MyGoWorkspace/src/github.com/shurcooL/glfw3/glfw/src/x11_monitor.c:218: undefined reference to `XineramaQueryScreens'
collect2: error: ld returned 1 exit status
```

Tested (the non-Wayland path) on a fresh VM with Ubuntu 14.04.

I didn't test the Wayland path, but it looks like the flag is needed for both non-Wayland and Wayland paths.
