### PR TITLE
v3.3/glfw: add FreeBSD support to the glfw joystick code

### DIFF
--- a/v3.3/glfw/c_glfw_freebsd.go
+++ b/v3.3/glfw/c_glfw_freebsd.go
@@ -3,6 +3,7 @@
 package glfw
 
 /*
+#cgo LDFLAGS: -linotify
 #ifdef _GLFW_WAYLAND
 	#include "glfw/src/wl_init.c"
 	#include "glfw/src/wl_monitor.c"
@@ -20,7 +21,7 @@ package glfw
 	#include "glfw/src/x11_window.c"
 	#include "glfw/src/glx_context.c"
 #endif
-#include "glfw/src/null_joystick.c"
+#include "glfw/src/linux_joystick.c"
 #include "glfw/src/posix_time.c"
 #include "glfw/src/posix_thread.c"
 #include "glfw/src/xkb_unicode.c"

--- a/v3.3/glfw/glfw/src/linux_joystick.c
+++ b/v3.3/glfw/glfw/src/linux_joystick.c
@@ -283,7 +283,7 @@ GLFWbool _glfwInitJoysticksLinux(void)
 
     // Continue without device connection notifications if inotify fails
 
-    if (regcomp(&_glfw.linjs.regex, "^event[0-9]\\+$", 0) != 0)
+    if (regcomp(&_glfw.linjs.regex, "^event[0-9][0-9]*$", 0) != 0)
     {
         _glfwInputError(GLFW_PLATFORM_ERROR, "Linux: Failed to compile regex");
         return GLFW_FALSE;

--- a/v3.3/glfw/glfw/src/linux_joystick.h
+++ b/v3.3/glfw/glfw/src/linux_joystick.h
@@ -25,7 +25,11 @@
 //========================================================================
 
 #include <linux/input.h>
+#ifdef __linux__
 #include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
 #include <regex.h>
 
 #define _GLFW_PLATFORM_JOYSTICK_STATE         _GLFWjoystickLinux linjs

--- a/v3.3/glfw/glfw/src/wl_init.c
+++ b/v3.3/glfw/glfw/src/wl_init.c
@@ -1157,7 +1157,7 @@ int _glfwPlatformInit(void)
     // Sync so we got all initial output events
     wl_display_roundtrip(_glfw.wl.display);
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     if (!_glfwInitJoysticksLinux())
         return GLFW_FALSE;
 #endif
@@ -1217,7 +1217,7 @@ int _glfwPlatformInit(void)
 
 void _glfwPlatformTerminate(void)
 {
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
     _glfwTerminateJoysticksLinux();
 #endif
     _glfwTerminateEGL();

--- a/v3.3/glfw/glfw/src/wl_platform.h
+++ b/v3.3/glfw/glfw/src/wl_platform.h
@@ -47,7 +47,7 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceWaylandPresentationSupportKHR
 
 #include "posix_thread.h"
 #include "posix_time.h"
-#ifdef __linux__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include "linux_joystick.h"
 #else
 #include "null_joystick.h"

--- a/v3.3/glfw/glfw/src/x11_init.c
+++ b/v3.3/glfw/glfw/src/x11_init.c
@@ -1094,7 +1094,7 @@ int _glfwPlatformInit(void)
         }
     }
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
     if (!_glfwInitJoysticksLinux())
         return GLFW_FALSE;
 #endif
@@ -1187,7 +1187,7 @@ void _glfwPlatformTerminate(void)
     _glfwTerminateEGL();
     _glfwTerminateGLX();
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
     _glfwTerminateJoysticksLinux();
 #endif
 }

--- a/v3.3/glfw/glfw/src/x11_platform.h
+++ b/v3.3/glfw/glfw/src/x11_platform.h
@@ -155,7 +155,7 @@ typedef VkBool32 (APIENTRY *PFN_vkGetPhysicalDeviceXcbPresentationSupportKHR)(Vk
 #include "glx_context.h"
 #include "egl_context.h"
 #include "osmesa_context.h"
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
 #include "linux_joystick.h"
 #else
 #include "null_joystick.h"

--- a/v3.3/glfw/glfw/src/x11_window.c
+++ b/v3.3/glfw/glfw/src/x11_window.c
@@ -2771,7 +2771,7 @@ void _glfwPlatformPollEvents(void)
 {
     _GLFWwindow* window;
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__FreeBSD__)
     _glfwDetectJoystickConnectionLinux();
 #endif
     XPending(_glfw.x11.display);


### PR DESCRIPTION
Tested with the multimedia/webcamd port as "driver", and an
Xbox One game pad. Assumes "Linux" for game pad definitions,
which seems right as webcamd actually is wrapping the Linux
drivers.

Note that part of this may have to be synced upstream with glfw.
No idea how this process works in go-gl/glfw.

Explanation of the parts:

- This adds a dependency on the devel/inotify port. Seems like lots of other stuff already uses it anyway, I did not have to install it.
- Adapted `linux_joystick` to also work on FreeBSD:
  - Simplified the regular expression; in FreeBSD basic REs, `+` does not exist there.
  - `PATH_MAX` comes from `<limits.h>`.
- Changed lots of ifdefs to also include FreeBSD.