### PR TITLE
v3.3/glfw: add openbsd support

### DIFF
--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -41,15 +41,15 @@ package glfw
 // BSD Build Tags
 // ----------------
 // GLFW Options:
+#cgo openbsd pkg-config: x11 xau xcb xdmcp
 #cgo freebsd pkg-config: glfw3
 #cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
 #cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
-#cgo openbsd CFLAGS: -I/usr/X11R6/include
 
 // Linker Options:
 #cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama
 #cgo freebsd,wayland LDFLAGS: -lm -lGL -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
-#cgo openbsd LDFLAGS: -L/usr/X11R6/lib -lm -lX11 -lxcb -lXau -lXdmcp
+#cgo openbsd LDFLAGS: -lm
 */
 import "C"

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -41,8 +41,8 @@ package glfw
 // BSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo openbsd pkg-config: x11 xau xcb xdmcp
 #cgo freebsd pkg-config: glfw3
+#cgo openbsd pkg-config: x11 xau xcb xdmcp
 #cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
 #cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -45,7 +45,6 @@ package glfw
 #cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
 #cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
-#cgo openbsd CFLAGS: -I/usr/X11R6/include
 
 // Linker Options:
 #cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -38,16 +38,18 @@ package glfw
 #cgo linux,!wayland LDFLAGS: -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lm -lXinerama -ldl -lrt
 #cgo linux,wayland LDFLAGS: -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon -lm -ldl -lrt
 
-// FreeBSD Build Tags
+// BSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo freebsd pkg-config: glfw3
-#cgo freebsd CFLAGS: -D_GLFW_HAS_DLOPEN
-#cgo freebsd,!wayland CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
+#cgo freebsd openbsd pkg-config: glfw3
+#cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
+#cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
+#cgo openbsd CFLAGS: -I/usr/X11R6/include
 
 // Linker Options:
 #cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama
 #cgo freebsd,wayland LDFLAGS: -lm -lGL -lwayland-client -lwayland-cursor -lwayland-egl -lxkbcommon
+#cgo openbsd LDFLAGS: -L/usr/X11R6/lib -lm -lX11 -lxcb -lXau -lXdmcp
 */
 import "C"

--- a/v3.3/glfw/build.go
+++ b/v3.3/glfw/build.go
@@ -41,10 +41,11 @@ package glfw
 // BSD Build Tags
 // ----------------
 // GLFW Options:
-#cgo freebsd openbsd pkg-config: glfw3
+#cgo freebsd pkg-config: glfw3
 #cgo freebsd openbsd CFLAGS: -D_GLFW_HAS_DLOPEN
 #cgo freebsd,!wayland openbsd CFLAGS: -D_GLFW_X11 -D_GLFW_HAS_GLXGETPROCADDRESSARB
 #cgo freebsd,wayland CFLAGS: -D_GLFW_WAYLAND
+#cgo openbsd CFLAGS: -I/usr/X11R6/include
 
 // Linker Options:
 #cgo freebsd,!wayland LDFLAGS: -lm -lGL -lX11 -lXrandr -lXxf86vm -lXi -lXcursor -lXinerama

--- a/v3.3/glfw/c_glfw_bsd.go
+++ b/v3.3/glfw/c_glfw_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd
+// +build freebsd openbsd
 
 package glfw
 

--- a/v3.3/glfw/native_linbsd.go
+++ b/v3.3/glfw/native_linbsd.go
@@ -1,4 +1,4 @@
-// +build linux,!wayland freebsd,!wayland
+// +build linux,!wayland freebsd,!wayland openbsd
 
 package glfw
 


### PR DESCRIPTION
partially fixes #288

simple adaptations to add openbsd support. this makes `fyne.io/fyne/v2/cmd/fyne_demo/` run on my OpenBSD-current machine. i don't have a netbsd system available, but hopefully this makes it clear which 8-ish changes a netbsd user would need to make to support that too