### PR TITLE
v3.3/glfw: format glfw_tree_rebuild.go

### DIFF
--- a/v3.3/glfw/glfw_tree_rebuild.go
+++ b/v3.3/glfw/glfw_tree_rebuild.go
@@ -7,5 +7,6 @@ package glfw
 // generate` on this package. This exists to invalidate the build cache (see
 // https://github.com/go-gl/glfw/issues/269), which is unaffected by C source
 // inputs.
+//
 //lint:ignore U1000 ^
-const upstreamTreeSHA = "a4a3bc8c0f4e37695a4de3f51cd7123bc186043b" 
+const upstreamTreeSHA = "a4a3bc8c0f4e37695a4de3f51cd7123bc186043b"


### PR DESCRIPTION
CI is correctly finding a formatting issue: https://github.com/go-gl/glfw/actions/runs/13575085829/job/37949278897. This should fix it. Generated with [git-generate](https://rsc.io/rf/git-generate):

```
[git-generate]
cd v3.3/glfw
go fmt ./...
```