### PR TITLE
Fix for programs crassing when display goes idle

### DIFF
--- a/v3.3/glfw/glfw/src/x11_monitor.c
+++ b/v3.3/glfw/glfw/src/x11_monitor.c
@@ -150,6 +150,10 @@ void _glfwPollMonitorsX11(void)
             }
 
             XRRCrtcInfo* ci = XRRGetCrtcInfo(_glfw.x11.display, sr, oi->crtc);
+            if (!ci) {
+                XRRFreeOutputInfo(oi);
+                continue;
+            }
             if (ci->rotation == RR_Rotate_90 || ci->rotation == RR_Rotate_270)
             {
                 widthMM  = oi->mm_height;


### PR DESCRIPTION
As reported in https://github.com/fyne-io/fyne/issues/5899 , apps seem to crash when they are visible and the display goes through an idle -> wake change.

Running with this patch seems to have resolved my issue. This is a similar fix to what was done in kitty: https://github.com/kovidgoyal/kitty/commit/ab7f3310c4f7982026a897155eabb097683658b2