### PR TITLE
glfw/v3.3: fix build warnings

### DIFF
--- a/v3.3/glfw/glfw/src/wl_window.c
+++ b/v3.3/glfw/glfw/src/wl_window.c
@@ -26,7 +26,9 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 
@@ -3047,4 +3049,3 @@ GLFWAPI struct wl_surface* glfwGetWaylandWindow(GLFWwindow* handle)
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     return window->wl.surface;
 }
-

--- a/v3.3/glfw/glfw/src/x11_window.c
+++ b/v3.3/glfw/glfw/src/x11_window.c
@@ -27,7 +27,9 @@
 // It is fine to use C99 in this file because it will not be built with VS
 //========================================================================
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include "internal.h"
 
@@ -3234,4 +3236,3 @@ GLFWAPI const char* glfwGetX11SelectionString(void)
     _GLFW_REQUIRE_INIT_OR_RETURN(NULL);
     return getSelectionString(_glfw.x11.PRIMARY);
 }
-


### PR DESCRIPTION
This PR fixes this build warning:

```
# github.com/go-gl/glfw/v3.3/glfw
In file included from ../../.cache/cgs/GOMODCACHE/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20240506104042-037f3cc74f2a/c_glfw_lin.go:10:
../../.cache/cgs/GOMODCACHE/github.com/go-gl/glfw/v3.3/glfw@v0.0.0-20240506104042-037f3cc74f2a/glfw/src/wl_window.c:29:9: warning: ‘_GNU_SOURCE’ redefined
   29 | #define _GNU_SOURCE
      |         ^~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```