### PR TITLE
glfw/v3.4: Improve build constraints for x11 & wayland handling

### DIFF
--- a/v3.4/glfw/native_linbsd_wayland.go
+++ b/v3.4/glfw/native_linbsd_wayland.go
@@ -1,5 +1,4 @@
-//go:build (linux && wayland) || (freebsd && wayland) || (netbsd && wayland) || (openbsd && wayland)
-// +build linux,wayland freebsd,wayland netbsd,wayland openbsd,wayland
+//go:build (linux || freebsd || netbsd || openbsd) && ((!x11 && !wayland) || wayland)
 
 package glfw
 

--- a/v3.4/glfw/native_linbsd_x11.go
+++ b/v3.4/glfw/native_linbsd_x11.go
@@ -1,5 +1,4 @@
-//go:build (linux && !x11 && !wayland) || (linux && x11) || (freebsd && !wayland) || (netbsd && !wayland) || (openbsd && !wayland)
-// +build linux,!x11,!wayland linux,x11 freebsd,!wayland netbsd,!wayland openbsd,!wayland
+//go:build (linux || freebsd || netbsd || openbsd) && ((!x11 && !wayland) || x11)
 
 package glfw
 

--- a/v3.4/glfw/not_wayland.go
+++ b/v3.4/glfw/not_wayland.go
@@ -1,4 +1,4 @@
-//go:build !((linux && wayland) || (freebsd && wayland) || (netbsd && wayland) || (openbsd && wayland))
+//go:build (linux || freebsd || netbsd || openbsd) && (x11 && !wayland)
 
 package glfw
 


### PR DESCRIPTION
Fixed the build tags for linux to correctly expose surfaces for x11 and wayland.

The logic is now:

* No build tags: expose both x11 and wayland
* Either `x11` or `wayland`: expose only one
* Both `x11,wayland`: expose both x11 and wayland

I've removed the old build constraint syntax as the minimum go version is defined as 1.19 anyways.