### PR TITLE
Fix build on BSDs

### DIFF
--- a/v3.4/glfw/c_glfw_bsd.go
+++ b/v3.4/glfw/c_glfw_bsd.go
@@ -21,7 +21,6 @@ package glfw
 	#include "glfw/src/x11_window.c"
 	#include "glfw/src/glx_context.c"
 #endif
-#include "glfw/src/null_joystick.c"
 #include "glfw/src/posix_module.c"
 #include "glfw/src/posix_poll.c"
 #include "glfw/src/posix_time.c"


### PR DESCRIPTION
Without this fix the build fails on BSDs with:
```
ld: error: duplicate symbol: _glfwInitJoysticksNull
>>> defined at null_joystick.c:35 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:35)
>>>            /tmp/go-link-1630102477/000011.o:(_glfwInitJoysticksNull)
>>> defined at null_joystick.c:35 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:35)
>>>            /tmp/go-link-1630102477/000012.o:(.text+0x4300)

ld: error: duplicate symbol: _glfwTerminateJoysticksNull
>>> defined at null_joystick.c:40 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:40)
>>>            /tmp/go-link-1630102477/000011.o:(_glfwTerminateJoysticksNull)
>>> defined at null_joystick.c:40 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:40)
>>>            /tmp/go-link-1630102477/000012.o:(.text+0x4330)

ld: error: duplicate symbol: _glfwPollJoystickNull
>>> defined at null_joystick.c:44 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:44)
>>>            /tmp/go-link-1630102477/000011.o:(_glfwPollJoystickNull)
>>> defined at null_joystick.c:44 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:44)
>>>            /tmp/go-link-1630102477/000012.o:(.text+0x4360)

ld: error: duplicate symbol: _glfwGetMappingNameNull
>>> defined at null_joystick.c:49 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:49)
>>>            /tmp/go-link-1630102477/000011.o:(_glfwGetMappingNameNull)
>>> defined at null_joystick.c:49 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:49)
>>>            /tmp/go-link-1630102477/000012.o:(.text+0x4390)

ld: error: duplicate symbol: _glfwUpdateGamepadGUIDNull
>>> defined at null_joystick.c:54 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:54)
>>>            /tmp/go-link-1630102477/000011.o:(_glfwUpdateGamepadGUIDNull)
>>> defined at null_joystick.c:54 (/home/simon/Code/glfw/v3.4/glfw/glfw/src/null_joystick.c:54)
>>>            /tmp/go-link-1630102477/000012.o:(.text+0x43C0)
cc: error: linker command failed with exit code 1 (use -v to see invocation)
```